### PR TITLE
Hides excess authors

### DIFF
--- a/app/views/_authors.scala.html
+++ b/app/views/_authors.scala.html
@@ -1,0 +1,13 @@
+@(item: List[String])
+
+@for(author <- item.zipWithIndex) {
+  @if(author._2 < 10) {
+    @author._1;
+  } else {
+    <span class="author_toggleable hidden">@author._1;</span>
+  }
+}
+
+@if(item.length >= 10) {
+  <span class="author_etal">et al.</span>
+}

--- a/app/views/item.scala.html
+++ b/app/views/item.scala.html
@@ -8,7 +8,10 @@
   <div itemscope itemtype="http://schema.org/@item.contentType.get.label" class="jumbotron">
     <h3>~ @item.contentType.get.tag ~</h3>
     <h2 itemprop="name">@Html(item.metadataValue("title"))</h2>
-    <p itemprop="author">@item.metadataValues("author").mkString("; ")</p>
+    <p itemprop="author">
+      @_authors(item.metadataValues("author"))
+      <span class="hidden author_toggler btn">[show all @item.metadataValues("author").length authors]<span>
+    </p>
     <p><span class="muted">@item.metadataValue("citation")</span></p>
     <p>@HubUtils.pluralize(item.transfers, "transfer") since @HubUtils.fmtDate(item.created). @if(item.transfers > 0){Most recent @HubUtils.fmtDate(item.updated)}</p>
     <p>Appears in collection: <a href="@routes.Application.itemBrowse("collection", item.collectionId)">@Collection.findById(item.collectionId).get.description</a></p>
@@ -23,14 +26,20 @@
     </p>
   </div>
   <h3>Topics Arranged by Scheme</h3>
-  <ul class="nav nav-tabs">
+
+  <div role="tabpanel">
+
+  <!-- Nav tabs -->
+  <ul class="nav nav-tabs" role="tablist">
     @item.regularTopics.map { sc =>
-      <li><a href="#@sc._1" data-toggle="tab">@sc._1</a></li>
+      <li class="active"><a href="#@sc._1" data-toggle="tab">@sc._1</a></li>
     }
   </ul>
+
+  <!-- Tab panes -->
   <div class="tab-content">
     @item.regularTopics.map { sc =>
-      <div class="tab-pane" id="@sc._1">
+      <div role="tabpanel" class="tab-pane active" id="@sc._1">
         <p>@Scheme.findByTag(sc._1).get.description</p>
         <ul>
           @sc._2.map { tp =>
@@ -38,6 +47,32 @@
           }
         </ul>
       </div>
-      }
+    }
   </div>
+
+</div>
 }
+
+<script>
+$(function() {
+  var hidable_authors = $(".author_toggleable").length;
+  var author_toggle_text = $(".author_toggler").text();
+
+  //$(".toggleable").toggle();
+
+  if (hidable_authors > 0) {
+    $(".author_toggler").removeClass("hidden");
+  }
+
+  $(".author_toggler").click(function() {
+    $(".author_etal").toggle();
+    if ($(".author_toggleable").is(":visible")) {
+      $(".author_toggleable").addClass("hidden");
+      $(".author_toggler").text(author_toggle_text);      
+    } else {
+      $(".author_toggleable").removeClass("hidden");
+      $(".author_toggler").text("Hide");
+    }
+  });
+});
+</script>

--- a/app/views/item_browse.scala.html
+++ b/app/views/item_browse.scala.html
@@ -22,14 +22,15 @@
 }
 
 @main("Item Browse -  TopicHub") {
-     <h2>Browse Items by @filter</h2>
-     <h3>@description</h3>
-     @pagination(page)
-     <dl>
-       @items.map { item =>
-         <dt><a href="@routes.Application.item(item.id)">@Html(item.metadataValue("title"))</a></dt>
-         <dd>@item.metadataValues("author").mkString("; ")</dd>
-       }
-     </dl>
-     @pagination(page)
+  <h2>Browse Items by @filter</h2>
+  <h3>@description</h3>
+
+  @pagination(page)
+    <dl>
+      @items.map { item =>
+        <dt><a href="@routes.Application.item(item.id)">@Html(item.metadataValue("title"))</a></dt>
+        <dd>@_authors(item.metadataValues("author"))</dd>
+      }
+    </dl>
+  @pagination(page)
 }

--- a/app/views/topic.scala.html
+++ b/app/views/topic.scala.html
@@ -30,7 +30,7 @@
      <dl>
      	@topic.recentItems(6).map { item =>
      	  <dt><a href="@routes.Application.item(item.id)">@Html(item.metadataValue("title"))</a></dt>
-        <dd>@item.metadataValues("author").mkString("; ")</dd>
+        <dd>@_authors(item.metadataValues("author"))</dd>
       }
      </dl>
 }


### PR DESCRIPTION
The first 10 authors are shown and `et al` added if there are more than 10.

For the Item view only, a total count of authors is displayed and the ability to hide/show
them is included.

Fixes #7

Some of this logic may be better done in the controller, but as it's been extracted out to
a partial view (i.e. method) it seems okay enough for now.