### PR TITLE
Display abstract for an item

### DIFF
--- a/app/views/item/show.scala.html
+++ b/app/views/item/show.scala.html
@@ -12,7 +12,7 @@
       @tags.item_authors(item.metadataValues("author"))
       <span class="hidden author_toggler btn">[show all @item.metadataValues("author").length authors]<span>
     </p>
-    <p><span class="muted">@item.metadataValue("citation")</span></p>
+    <p><span class="muted">@item.metadataValue("abstract")</span></p>
     <p>@HubUtils.pluralize(item.transfers, "transfer") since @HubUtils.fmtDate(item.created). @if(item.transfers > 0){Most recent @HubUtils.fmtDate(item.updated)}</p>
     <p>Appears in collection: <a href="@routes.Application.itemBrowse("collection", item.collectionId)">@Collection.findById(item.collectionId).get.description</a></p>
     <p>


### PR DESCRIPTION
closes #25 

This is the onlycode necessary to display the abstract along with the item. Everything else is done in configuration.

I'll paste in my updated `/cmodel` dump in a comment which includes the additional finders and mappings, etc.