### PR TITLE
Adds 'force' mode for knip (Known Item Pull)

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -242,10 +242,10 @@ object Application extends Controller {
     ).getOrElse(NotFound(views.html.static.trouble("No such harvest: " + id)))
   }
 
-  def pullKnownItem(cid: Int, hid: Int, oid: String) = Action { implicit request =>
+  def pullKnownItem(cid: Int, hid: Int, oid: String, force: Boolean) = Action { implicit request =>
     Collection.findById(cid).map ( coll =>
       Harvest.findById(hid).map( harvest => {
-        harvester ! (oid, coll, harvest)
+        harvester ! (oid, coll, harvest, force)
         Ok(views.html.harvest.index("pulled: " + oid))
       }).getOrElse(NotFound(views.html.static.trouble("No such harvest: " + hid)))
     ).getOrElse(NotFound(views.html.static.trouble("No such collection: " + cid)))

--- a/conf/routes
+++ b/conf/routes
@@ -28,7 +28,7 @@ GET     /collections                controllers.Application.collections
 GET     /harvest/:id                controllers.Application.harvest(id: Int)
 GET     /harvest/:id/start          controllers.Application.startHarvest(id: Int)
 GET     /harvest/:id/delete         controllers.Application.deleteHarvest(id: Int)
-GET     /knip/:cid/:hid/:oid        controllers.Application.pullKnownItem(cid: Int, hid: Int, oid: String)
+GET     /knip/:cid/:hid/:oid        controllers.Application.pullKnownItem(cid: Int, hid: Int, oid: String, force: Boolean ?= false)
 
 # Scheme pages
 GET     /schemes                    controllers.Application.schemes


### PR DESCRIPTION
    Invoked via a URL parameter to /knip: force=true (defaults to false) with behavior that if force is false,
    an attempt to add an item that already exists with given obj_key will fail, whereas if force is true, current
    item will be deleted and a new item with same obj_key created.
    fixes #26
    fixes #28