### PR TITLE
12 heroku

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,5 +16,6 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-s3" % "1.9.14",
   "org.scalesxml" %% "scales-xml" % "0.6.0-M3",
   "org.scalesxml" %% "scales-jaxen" % "0.6.0-M3" intransitive(),
-  "jaxen" % "jaxen" % "1.1.6" intransitive()
+  "jaxen" % "jaxen" % "1.1.6" intransitive(),
+  "org.postgresql" % "postgresql" % "9.4-1200-jdbc41"
 )

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -36,10 +36,8 @@ application.langs="en"
 # You can declare as many datasources as you want.
 # By convention, the default datasource is named `default`
 #
-db.default.driver=org.h2.Driver
-db.default.url="jdbc:h2:mem:play;MODE=PostgreSQL"
-db.default.user=sa
-db.default.password=""
+db.default.driver=org.postgresql.Driver
+db.default.url=${DATABASE_URL}
 
 # Evolutions
 # ~~~~~

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -44,6 +44,9 @@ db.default.url=${DATABASE_URL}
 # You can disable evolutions if needed
 # evolutionplugin=disabled
 
+# Auto apply evolutions
+applyEvolutions.default=true
+
 # Logger
 # ~~~~~
 # You can also configure logback (http://logback.qos.ch/),


### PR DESCRIPTION
closes #12 

This switches to postgres and reads the database URL from an ENV. DATABASE_URL is how heroku populates the db so doing the same in dev makes it easier.

You'll need to setup a postgres db locally and do something like:
`export DATABASE_URL=jdbc:postgresql://localhost/scoap3`

The only other change is that evolutions are automatically applied in `application.conf`. If it's preferred to use `Procfile` please let me know and I'll back out that change and add a `Procfile`.
