### PR TITLE
Switches route for Item show

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -74,10 +74,10 @@ object Application extends Controller {
     )
   }
 
-  def item(id: Int) = Action { implicit request =>
-    Item.findById(id).map( item =>
+  def item(obj_key: String) = Action { implicit request =>
+    Item.findByKey(obj_key).map( item =>
       Ok(views.html.item.show(item))
-    ).getOrElse(NotFound(views.html.static.trouble("No such item: " + id)))
+    ).getOrElse(NotFound(views.html.static.trouble("No such item: " + obj_key)))
   }
 
   def itemBrowse(filter: String, id: Int, page: Int) = Action { implicit request =>

--- a/app/views/item/browse.scala.html
+++ b/app/views/item/browse.scala.html
@@ -27,7 +27,7 @@
      @pagination(page)
      <dl>
        @items.map { item =>
-         <dt><a href="@routes.Application.item(item.id)">@Html(item.metadataValue("title"))</a></dt>
+         <dt><a href="@routes.Application.item(item.objKey)">@Html(item.metadataValue("title"))</a></dt>
          <dd>@tags.item_authors(item.metadataValues("author"))</dd>
        }
      </dl>

--- a/app/views/topic/show.scala.html
+++ b/app/views/topic/show.scala.html
@@ -29,7 +29,7 @@
      <h3>Recent Articles <a href="@routes.Application.itemBrowse("topic", topic.id, 0)">Browse All</a></h3>
      <dl>
      	@topic.recentItems(6).map { i =>
-     	  <dt><a href="@routes.Application.item(i.id)">@Html(i.metadataValue("title"))</a></dt>
+     	  <dt><a href="@routes.Application.item(i.objKey)">@Html(i.metadataValue("title"))</a></dt>
         <dd>@tags.item_authors(i.metadataValues("author"))</dd>
       }
      </dl>

--- a/conf/routes
+++ b/conf/routes
@@ -79,7 +79,7 @@ GET     /resmap/:id/scheme          controllers.Application.removeResourceMappin
 #GET     /items                       controllers.Application.items
 #GET     /items/search                controllers.Application.itemSearch(topicId: String, page: Int)
 GET     /items/browse                controllers.Application.itemBrowse(filter: String, id: Int, page: Int ?= 0)
-GET     /item/:id                    controllers.Application.item(id: Int)
+GET     /item/:obj_key               controllers.Application.item(obj_key: String)
 
 # Topic pages
 GET     /topics                      controllers.Application.topics


### PR DESCRIPTION
Closes #36 

This PR is open primarily as a place to discuss whether it may make sense to use `Item.obj_key` instead of `Item.id` in our URLs. If it does, we can merge this. If it does not, we can close it.

I think it would work well enough for Scoap3 data, but I haven't really thought about whether it may make things more difficult longterm.