### PR TITLE
Initial Item and Topic Search UI

### DIFF
--- a/app/controllers/Search.scala
+++ b/app/controllers/Search.scala
@@ -1,0 +1,48 @@
+package controllers
+
+import play.api.mvc._
+import play.api._
+import play.api.Play.current
+import play.api.libs.ws._
+import play.api.libs.concurrent.Execution.Implicits._
+import play.utils.UriEncoding
+import models._
+
+object Search extends Controller {
+
+  def index = Action {
+    Ok(views.html.search.index())
+  }
+
+  def results(q: String, target: String, page: Int, perpage: Int) = Action.async {
+    val indexSvc = Play.configuration.getString("hub.index.url").get
+    val encQuery = UriEncoding.encodePathSegment(q, "UTF-8")
+    val offset = (page) * perpage
+
+    val req = WS.url(indexSvc +  target + "/_search?q=" + encQuery 
+                    + "&from=" + offset + "&size=" + perpage)
+
+    println(req)
+
+    req.get().map { response =>
+      val json = response.json
+      //println(json)
+      val total_results = (json \ "hits" \\ "total")(0).as[Long]
+
+      println(total_results)
+      val hits = (json \ "hits" \\ "hits").head \\ "dbId" map(_.as[Int])
+      println("Size:" + hits.size)
+      hits foreach(x => println(x))
+
+      if (target == "item") {
+        val items = hits flatMap ( id => Item.findById(id) )
+        Ok(views.html.search.item_results(q, target, page, perpage, items, total_results))
+      } else if (target == "topic") {
+        val topics = hits flatMap ( id => Topic.findById(id) )
+        Ok(views.html.search.topic_results(q, target, page, perpage, topics, total_results))
+      } else {
+        NotFound(views.html.static.trouble("Only Topic or Item searching are supported."))
+      }
+    }
+  }
+}

--- a/app/views/layout/main.scala.html
+++ b/app/views/layout/main.scala.html
@@ -52,6 +52,7 @@
                 <li><a id="nav_workbench" href="@routes.Application.editSubscriber(1)">Interests</a></li>
               }
               <li><a id="nav_workbench" href="@routes.Application.workbench">Workbench</a></li>
+              <li><a id="nav_search" href="@routes.Search.index">Search</a></li>
             </ul>
           </div>
         </div>

--- a/app/views/search/index.scala.html
+++ b/app/views/search/index.scala.html
@@ -1,0 +1,19 @@
+@*****************************************************************************
+* Search Index page                                                          *
+* Copyright (c) 2015 MIT Libraries                                           *
+*****************************************************************************@
+@*(implicit hubContext: HubContext)*@
+
+@layout.main("Search - TopicHub") {
+  <div class="container-fluid">
+    <div class="row-fluid">
+      <div class="col-md-12">
+        <div class="jumbotron">
+          <p>Search for stuff!</p>
+
+          @searchform("", "topic")
+        </div>
+      </div>
+    </div>
+  </div>
+}

--- a/app/views/search/item_results.scala.html
+++ b/app/views/search/item_results.scala.html
@@ -1,0 +1,41 @@
+@*****************************************************************************
+* Search results page                                                        *
+* Copyright (c) 2015 MIT Libraries                                           *
+*****************************************************************************@
+@(q: String, target: String, page: Int, perpage: Int, items: Seq[Item], total: Long)@*(implicit hubContext: HubContext)*@
+
+@layout.main("Search - TopicHub") {
+  <div class="container-fluid">
+    <div class="row-fluid">
+      <div class="col-md-12">
+          @searchform(q, target)
+
+          <p>Searchterm: @q</p>
+
+          <p>@tags.summary(page, perpage, total, items.length)</p>
+
+          <ol start="@(page * perpage + 1)">
+          
+            @for(i <- items) {
+              <li>Title: <a href="@routes.Application.item(i.id)">@i.metadataValue("title")</a></li>
+
+              Topics:
+              <ul>
+              @for(tc <- i.regularTopics) {
+                <li>@tc._1
+                  <ul>
+                  @for(t <- tc._2) {
+                    <a href="@routes.Application.topic(t.id)">@t.tag</a> | 
+                  }
+                  </ul>
+                </li>                 
+              }
+              </ul>
+            }
+          </ol>
+      </div>
+
+      @tags.pagination(page, perpage, total, routes.Search.results(q, target).toString, items.length)
+    </div>
+  </div>
+}

--- a/app/views/search/searchform.scala.html
+++ b/app/views/search/searchform.scala.html
@@ -1,0 +1,22 @@
+@(q: String, target: String)
+<form class="form-horizontal" action="/search/results">
+  <div class="form-group">
+    <label for="inputQuery" class="col-sm-2 control-label">Searchterm</label>
+    <div class="col-sm-8">
+      <input type="email" name="q" class="form-control" id="inputQuery" placeholder="why don't you just type what you want to find..." value="@q">
+    </div>
+    <button type="submit" class="btn btn-primary">Search!</button>
+  </div>
+  
+  <div class="form-group">
+    <div class="col-sm-2 control-label"><label for="target">Target</label></div>
+    <div class="col-sm-10">
+      <label class="radio-inline">
+        <input type="radio" name="target" id="target_topic" value="topic" @if(target=="topic"){checked}> Topic
+      </label>
+      <label class="radio-inline">
+        <input type="radio" name="target" id="target_item" value="item" @if(target=="item"){checked}> Item
+      </label>
+    </div>
+  </div>
+</form>

--- a/app/views/search/topic_results.scala.html
+++ b/app/views/search/topic_results.scala.html
@@ -1,0 +1,28 @@
+@*****************************************************************************
+* Search results page                                                        *
+* Copyright (c) 2015 MIT Libraries                                           *
+*****************************************************************************@
+@(q: String, target: String, page: Int, perpage: Int, topics: Seq[Topic], total: Long)@*(implicit hubContext: HubContext)*@
+
+@layout.main("Search - TopicHub") {
+  <div class="container-fluid">
+    <div class="row-fluid">
+      <div class="col-md-12">
+        @searchform(q, target)
+
+        <p>Searchterm: @q</p>
+
+        <p>@tags.summary(page, perpage, total, topics.length)</p>
+
+        Topic:
+        <ol start="@(page * perpage + 1)">
+          @for(t <- topics) {
+            <li><a href="@routes.Application.topic(t.id)">@t.tag</a></li>
+          }
+        </ol>
+      </div>
+
+      @tags.pagination(page, perpage, total, routes.Search.results(q, target).toString, topics.length)
+    </div>
+  </div>
+}

--- a/app/views/tags/pagination.scala.html
+++ b/app/views/tags/pagination.scala.html
@@ -1,12 +1,11 @@
 @(page: Int, perpage: Int, total: Long, urlpattern: String, length: Int)
-@* perpage is currently not implemented but is here as a placeholder *@
 
 @next_page_url = {
-  @urlpattern.concat("&page=").concat((page + 1).toString)
+  @urlpattern.concat("&page=").concat((page + 1).toString).concat("&perpage=").concat(perpage.toString)
 }
 
 @prev_page_url = {
-  @urlpattern.concat("&page=").concat((page - 1).toString)
+  @urlpattern.concat("&page=").concat((page - 1).toString).concat("&perpage=").concat(perpage.toString)
 }
 
 <nav>

--- a/app/views/tags/summary.scala.html
+++ b/app/views/tags/summary.scala.html
@@ -3,5 +3,5 @@
 @if(length >= total){
   Viewing all @length records.
 } else {
-  Viewing @(page * 10 + 1) - @(page * 10 + length) of @total
+  Viewing @(page * perpage + 1) - @(page * perpage + length) of @total
 } 

--- a/conf/routes
+++ b/conf/routes
@@ -102,6 +102,10 @@ GET     /subscriber/:id/removeInt/:sid  controllers.Application.removeSubscriber
 POST    /subscribers                controllers.Application.createSubscriber
 #POST    /subscriber/:sid/channels   controllers.Application.createChannel(sid: Long)
 
+# Search pages
+GET     /search                     controllers.Search.index
+GET     /search/results             controllers.Search.results(q: String, target: String ?="topic", page: Int ?=0, perpage: Int ?=25)
+
 # Administrative services
 #GET     /reindex/:dtype             controllers.Application.reindex(dtype: String)
 GET     /workbench                   controllers.Application.workbench


### PR DESCRIPTION
closes #40

You'll notice I've created an additional controller solely for Search related pages. I like it this way, but I can move this work back to `controllers/Application.scala` if it's preferred for this project. If we do both like it, I'll open a ticket to move move most of `controllers/Application.scala` into smaller purpose focused controllers (likely along `route` lines like the `views` folders hierarchy).

Also worth noting is that I didn't use the Play form helper. I found it clunky for this non-model backed form (I did have it in there for a while but to get the layout I wanted this was saner). #23 may want to consider just ditching the helpers as well, although for model backed forms it may make sense to stick with helpers and write a custom renderer... I'll leave further discussion on that to the related ticket though.

Finally, I didn't add the search form into the header. We can do that if it's preferred.