### PR TITLE
Prevents multiple assignment of same topic to an item. Fixes #74

### DIFF
--- a/app/models/Item.scala
+++ b/app/models/Item.scala
@@ -31,6 +31,14 @@ case class Item(id: Int,            // DB key
                 updated: Date,      // Time of last transfer
                 transfers: Int)  {  // Number of transfers
 
+  def hasTopic(topic: Topic): Boolean = {
+    DB.withConnection { implicit c =>
+      val count = SQL("select count(*) as c from item_topic where topic_id = {topic_id} and item_id = {item_id}")
+      .on('topic_id -> topic.id, 'item_id -> id).apply.head
+      count[Long]("c") > 0
+    }
+  }
+
   def addTopic(topic: Topic) {
     DB.withConnection { implicit c =>
       SQL("insert into item_topic (item_id, item_created, topic_id) values ({item_id}, {item_created}, {topic_id})")

--- a/app/workers/Cataloger.scala
+++ b/app/workers/Cataloger.scala
@@ -81,8 +81,10 @@ class Cataloger(resmap: ResourceMap, content: StoredContent) {
           case Some(x) => x
           case _ => createTopic(scheme, id, lblHits(idx)) //Topic.create(scheme.id, id, lblHits(idx)); Topic.forSchemeAndId(scheme.schemeId, id).get
         }
-        item.addTopic(tp)
-        addedTopics += 1
+        if (! item.hasTopic(tp)) {
+          item.addTopic(tp)
+          addedTopics += 1
+        }
         idx += 1
       }
     }


### PR DESCRIPTION
@JPrevost Could you have a look and comment? The bug report was for multiple item appearances under a topic - but I think the cause is the other side of the equation: when a finder obtains multiple occurrences of the same value, it blindly adds a link for each. For the typical case (say cardinality n for authors) each value will be distinct, but in your case they were the same. Fix just checks for existence of a topic-item link, and skips the add. Thanks