### PR TITLE
METS generator

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -101,6 +101,12 @@ object Application extends Controller {
     ).getOrElse(NotFound(views.html.static.trouble("No such collection")))
   }
 
+  def itemPackage(id: Int) = Action { implicit request =>
+    Item.findById(id).map( item =>
+      Ok(item.toMets)
+    ).getOrElse(NotFound(views.html.static.trouble("No such item: " + id)))
+  }
+
   def topics = Action { implicit request =>
     Ok(views.html.topic.index(Scheme.withGentype("topic").filter(!_.tag.equals("meta"))))
   }

--- a/app/views/item/show.scala.html
+++ b/app/views/item/show.scala.html
@@ -27,8 +27,8 @@
       }
       @*<a rel="tooltip" title="download whole package to desktop" href="@routes.Application.itemFile(item.id)" class="btn btn-primary btn-large">Download &raquo;</a>
       <a rel="tooltip" title="send an email notification with link to this item" href="@routes.Application.itemTransfer(item.id, "alert")" class="btn btn-primary btn-large pull-right">Remind Me &raquo;</a>
-      <a rel="tooltip" title="start a SWORD deposit of package to my repository" href="@routes.Application.itemTransfer(item.id, "package")" class="btn btn-primary btn-large pull-right">Deposit &raquo;</a>
       *@
+      <a rel="tooltip" title="start a SWORD deposit of package to my repository" href="@routes.Application.itemPackage(item.id)" class="btn btn-primary btn-large pull-right">Deposit &raquo;</a>
     </p>
   </div>
   <h3>Topics Arranged by Scheme</h3>

--- a/conf/routes
+++ b/conf/routes
@@ -88,6 +88,7 @@ GET     /resmap/:id/scheme          controllers.Application.removeResourceMappin
 #GET     /items/search                controllers.Application.itemSearch(topicId: String, page: Int)
 GET     /items/browse                controllers.Application.itemBrowse(filter: String, id: Int, page: Int ?= 0)
 GET     /item/:id                    controllers.Application.item(id: Int)
+GET     /item/package/:id            controllers.Application.itemPackage(id: Int)
 
 # Topic pages
 GET     /topics                      controllers.Application.topics


### PR DESCRIPTION
There are a few METS field id values that seem arbitrary so they are
left out (they are incremental div id numbers that are not referenced
elsewhere for example).

File names are their own method, so the Packager should be able to use
the same method to generate a name matching the `Item#toMets` method. (And
thus if we need to make a change, we should be able to just change what
that method does without too much concern.

`toMets` should be fairly forgiving and just generate a file with
whatever metadata exists for an Item that we’ve mapped to METS. As
such, the notion of a ContentProfile is not actually being checked for
this work. I’m fine with adding it back in if we decide an Analyst
really will want the flexibility to Catalog metadata without including
it in the mets.xml file.

The packager will be responsible for calling this method and writing
the actual `mets.xml` file into the zip.

The route `/item/package/:id` is a convenience for testing this at this
time. Eventually that route will be used to delivery one-off Sword
packages to a configured repository. For now, it just dumps the mets
file to your browser.

I will update the Content Model in our private repo that extracts the
additional metadata fields this work uses (although it’s all optional
and will be excluded from output if it does not exist rather than
failing).

closes #86