### PR TITLE
Default DB URL and Fake Email Key

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -37,7 +37,8 @@ application.langs="en"
 # By convention, the default datasource is named `default`
 #
 db.default.driver=org.postgresql.Driver
-db.default.url=${DATABASE_URL}
+db.default.url="jdbc:postgresql://localhost/scoap3"
+db.default.url=${?DATABASE_URL}
 
 # Evolutions
 # ~~~~~
@@ -73,4 +74,5 @@ hub.index.url=${?BONSAI_URL}
 
 # URL of email service, and API key to use it
 hub.email.url="https://api.mailgun.net/v2/topichub.mailgun.org/messages"
-hub.email.apikey=${MAILGUN_API_KEY}
+hub.email.apikey="fake"
+hub.email.apikey=${?MAILGUN_API_KEY}


### PR DESCRIPTION
As a first round of work on #22, this provides default db url and a
fake email api key.

If they are defined in the ENV, the ENV values win, so Heroku and
Travis should remain fine with this config but this has the benefit of
not requiring setting those values if they are the development versions
like we already do for elasticsearch. If a developer or deployed server
desires non-default values, they can easily set via ENV.