### PR TITLE
Displays Subscription Status on Topic Results

### DIFF
--- a/app/controllers/Search.scala
+++ b/app/controllers/Search.scala
@@ -48,7 +48,7 @@ object Search extends Controller {
         Ok(views.html.search.item_results(q, target, page, perpage, items, total_results))
       } else if (target == "topic") {
         val topics = hits flatMap ( id => Topic.findById(id) )
-        Ok(views.html.search.topic_results(q, target, page, perpage, topics, total_results))
+        Ok(views.html.search.topic_results(q, target, page, perpage, topics, total_results, Subscriber.findById(1)))
       } else {
         NotFound(views.html.static.trouble("Only Topic or Item searching are supported."))
       }

--- a/app/views/search/item_results.scala.html
+++ b/app/views/search/item_results.scala.html
@@ -4,6 +4,8 @@
 *****************************************************************************@
 @(q: String, target: String, page: Int, perpage: Int, items: Seq[Item], total: Long)@*(implicit hubContext: HubContext)*@
 
+@start = @{(page * perpage + 1)}
+
 @layout.main("Search - TopicHub") {
   <div class="container-fluid">
     <div class="row-fluid">
@@ -14,25 +16,23 @@
 
           <p>@tags.summary(page, perpage, total, items.length)</p>
 
-          <ol start="@(page * perpage + 1)">
-          
-            @for(i <- items) {
-              <li>Title: <a href="@routes.ItemController.item(i.id)">@i.metadataValue("title")</a></li>
+          <ul class="list-group">
 
-              Topics:
-              <ul>
-              @for(tc <- i.regularTopics) {
-                <li>@tc._1
-                  <ul>
-                  @for(t <- tc._2) {
-                    <a href="@routes.Application.topic(t.id)">@t.tag</a> | 
-                  }
-                  </ul>
-                </li>                 
-              }
-              </ul>
+            @for((item, index) <- items.zip((Stream from start))) {
+              <li class="list-group-item">
+                <h4 class="list-group-item-heading">@index. Title: <a href="@routes.ItemController.item(item.id)">@item.metadataValue("title")</a></h4>
+
+              <p class="list-group-item-text">
+                @for(tc <- item.regularTopics) {
+                  <p style="text-indent: -10px; padding-left: 10px;"><strong>@tc._1</strong>
+                    @for(t <- tc._2) {
+                      <a href="@routes.Application.topic(t.id)">@t.tag</a> |
+                    }
+                  </p>
+                }
+              </p>
             }
-          </ol>
+          </ul>
       </div>
 
       @tags.pagination(page, perpage, total, routes.Search.results(q, target).toString, items.length)

--- a/app/views/search/topic_results.scala.html
+++ b/app/views/search/topic_results.scala.html
@@ -2,7 +2,29 @@
 * Search results page                                                        *
 * Copyright (c) 2015 MIT Libraries                                           *
 *****************************************************************************@
-@(q: String, target: String, page: Int, perpage: Int, topics: Seq[Topic], total: Long)@*(implicit hubContext: HubContext)*@
+@(q: String, target: String, page: Int, perpage: Int, topics: Seq[Topic], total: Long, sub: Option[Subscriber])@*(implicit hubContext: HubContext)*@
+
+@start = @{(page * perpage + 1)}
+
+@subscribed(t: Topic, sub: Subscriber) = @{
+  if(sub.hasInterest(t.scheme_id) && sub.subscribesTo(t.id) ) {
+    "subscribed"
+  } else {
+    "not_subscribed"
+  }
+}
+
+@star(t: Topic, sub: Subscriber) = @{
+  if(sub.hasInterest(t.scheme_id) && sub.subscribesTo(t.id) ) {
+    <span class="badge alert-success" data-toggle="tooltip" title="You are subscribed to this Topic">
+      <span class="glyphicon glyphicon-star" aria-hidden="true"></span>
+    </span>
+  } else {
+    <span class="badge progress-bar-danger" data-toggle="tooltip" title="You are NOT subscribed to this Topic">
+      <span class="glyphicon glyphicon-star" aria-hidden="true"></span>
+    </span>
+  }
+}
 
 @layout.main("Search - TopicHub") {
   <div class="container-fluid">
@@ -15,14 +37,24 @@
         <p>@tags.summary(page, perpage, total, topics.length)</p>
 
         Topic:
-        <ol start="@(page * perpage + 1)">
-          @for(t <- topics) {
-            <li><a href="@routes.Application.topic(t.id)">@t.tag</a></li>
+        <ul class="list-group">
+          @for((t, i) <- topics.zip((Stream from start))) {
+            <li class="list-group-item">
+              @i.
+              <a href="@routes.Application.topic(t.id)" class="@subscribed(t, sub.get)">@t.tag</a>
+              @star(t, sub.get)
+            </li>
           }
-        </ol>
+        </ul>
       </div>
 
       @tags.pagination(page, perpage, total, routes.Search.results(q, target).toString, topics.length)
     </div>
   </div>
 }
+
+<script>
+$(function () {
+  $('[data-toggle="tooltip"]').tooltip()
+})
+</script>

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -10,3 +10,13 @@ a.list-group-item {
 a.list-group-item:hover {
   text-decoration: underline !important;
 }
+
+.subscribed {
+  color: gray;
+  text-decoration: underline;
+}
+
+.not_subscribed {
+  font-weight: bold;
+  text-decoration: underline;
+}


### PR DESCRIPTION
This also includes some updated styling on both Topic and Item search
result pages.

closes #107 

This is just one way of how to distinguish between subscribed and non-subscribed Topics in search results.
![screen shot 2015-03-17 at 12 32 33 pm](https://cloud.githubusercontent.com/assets/1386650/6692210/ba063c9a-cca1-11e4-89f9-1140eb5817aa.png)
