### PR TITLE
Fix badges in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ SCOAP3 TopicHub
 This is a web application to allow users to discover, subscribe to,
 and obtain automatic delivery of, aggregations of article content from the SCOAP3 repository.
 
-[![Build Status](https://travis-ci.org/MITLibraries/scoap3hub.svg?branch=107_sub_status_in_search_results)](https://travis-ci.org/MITLibraries/scoap3hub) [![Coverage Status](https://coveralls.io/repos/MITLibraries/scoap3hub/badge.svg?branch=item_model_tests)](https://coveralls.io/r/MITLibraries/scoap3hub?branch=item_model_tests)
+[![Build Status](https://travis-ci.org/MITLibraries/scoap3hub.svg?branch=master)](https://travis-ci.org/MITLibraries/scoap3hub) [![Coverage Status](https://coveralls.io/repos/MITLibraries/scoap3hub/badge.svg?branch=master)](https://coveralls.io/r/MITLibraries/scoap3hub?branch=master)


### PR DESCRIPTION
CI and Coverage badges were point at a non-master branch.

Fixes #120