### PR TITLE
MIT OpenID proof of concept

### DIFF
--- a/app/services/OAuth2.scala
+++ b/app/services/OAuth2.scala
@@ -1,0 +1,80 @@
+package services
+
+import play.api.Application
+import play.api.Play
+import play.api.http.{MimeTypes, HeaderNames}
+import play.api.libs.ws.WS
+import play.api.libs.ws._
+import play.api.mvc.{Results, Action, Controller}
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class OAuth2(application: Application) {
+  lazy val mitAuthId = application.configuration.getString("mit.client.id").get
+  lazy val mitAuthSecret = application.configuration.getString("mit.client.secret").get
+
+  def getAuthorizationUrl(redirectUri: String, scope: String, state: String): String = {
+    val baseUrl = application.configuration.getString("mit.redirect.url").get
+    baseUrl.format(mitAuthId, redirectUri, scope, state)
+  }
+
+  def getToken(code: String): Future[String] = {
+    val tokenResponse = WS.url("https://oidc.mit.edu/token")(application).
+      withQueryString("client_id" -> mitAuthId,
+        "client_secret" -> mitAuthSecret,
+        "code" -> code,
+        "grant_type" -> "authorization_code",
+        "redirect_uri" -> "http://localhost:9000/_oauth-callback").
+      withAuth(mitAuthId, mitAuthSecret, WSAuthScheme.BASIC).
+      withHeaders(HeaderNames.ACCEPT -> MimeTypes.JSON).
+      post(Results.EmptyContent())
+
+    tokenResponse.flatMap { response =>
+      (response.json \ "access_token").asOpt[String].fold(Future.failed[String](new IllegalStateException("Sod off!"))) { accessToken =>
+        Future.successful(accessToken)
+      }
+    }
+  }
+}
+
+object OAuth2 extends Controller {
+  lazy val oauth2 = new OAuth2(Play.current)
+
+  def callback(codeOpt: Option[String] = None, stateOpt: Option[String] = None) = Action.async { implicit request =>
+    println(codeOpt)
+    println(stateOpt)
+    println(request.session.get("oauth-state"))
+    println(request)
+    (for {
+      code <- codeOpt
+      state <- stateOpt
+      oauthState <- request.session.get("oauth-state")
+    } yield {
+      if (state == oauthState) {
+        oauth2.getToken(code).map { accessToken =>
+          Redirect(services.routes.OAuth2.success()).withSession("oauth-token" -> accessToken)
+        }.recover {
+          case ex: IllegalStateException => Unauthorized(ex.getMessage)
+        }
+      }
+      else {
+        Future.successful(BadRequest("Invalid mit login"))
+      }
+    }).getOrElse(Future.successful(BadRequest("No parameters supplied")))
+  }
+
+  def success() = Action.async { request =>
+    println("___oath token start___")
+    println(request.session.get("oauth-token"))
+    println("___oath token end___")
+    implicit val app = Play.current
+    request.session.get("oauth-token").fold(Future.successful(Unauthorized("No way Jose"))) { authToken =>
+      WS.url("https://oidc.mit.edu/userinfo").
+        withHeaders(HeaderNames.AUTHORIZATION -> ("Bearer " + s"$authToken")).
+        get().map { response =>
+          Ok(response.json)
+        }
+    }
+  }
+}

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,6 +1,6 @@
 @(message: String, redirectUrl: String)
 
-@layout.main("Welcome to Play") {
+@layout.main("Login to SCOAP3 - TopicHub") {
     <h2>Not Yet Authenticated</h2>
-    <a href="@redirectUrl"><em><b>Log in with MITID!</b></em></a>
+    <a id="openid" href="@redirectUrl"><em><b>Log in with MITID!</b></em></a>
 }

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,0 +1,6 @@
+@(message: String, redirectUrl: String)
+
+@layout.main("Welcome to Play") {
+    <h2>Not Yet Authenticated</h2>
+    <a href="@redirectUrl"><em><b>Log in with MITID!</b></em></a>
+}

--- a/build.sbt
+++ b/build.sbt
@@ -17,5 +17,6 @@ libraryDependencies ++= Seq(
   "org.scalesxml" %% "scales-xml" % "0.6.0-M3",
   "org.scalesxml" %% "scales-jaxen" % "0.6.0-M3" intransitive(),
   "jaxen" % "jaxen" % "1.1.6" intransitive(),
-  "org.postgresql" % "postgresql" % "9.4-1200-jdbc41"
+  "org.postgresql" % "postgresql" % "9.4-1200-jdbc41",
+  "org.mockito" % "mockito-core" % "1.10.19" % "test"
 )

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -76,3 +76,10 @@ hub.index.url=${?BONSAI_URL}
 hub.email.url="https://api.mailgun.net/v2/topichub.mailgun.org/messages"
 hub.email.apikey="fake"
 hub.email.apikey=${?MAILGUN_API_KEY}
+
+mit.client.id="fake_key"
+mit.client.secret="fake_secret"
+mit.client.id=${?MIT_KEY}
+mit.client.secret=${?MIT_SECRET}
+mit.redirect.url="https://oidc.mit.edu/authorize?client_id=%s&redirect_uri=%s&scope=%s&state=%s&response_type=code"
+

--- a/conf/routes
+++ b/conf/routes
@@ -2,6 +2,11 @@
 # This file defines all application routes (Higher priority routes first)
 # ~~~~
 
+# OAuth2 Stuff
+GET        /_oauth-callback        services.OAuth2.callback(code: Option[String], state: Option[String])
+GET        /_oauth-success         services.OAuth2.success
+GET        /login                  controllers.Application.login
+
 # Home and informational page
 GET     /                           controllers.Application.index
 #GET     /explain                    controllers.Application.explain

--- a/test/ApplicationSpec.scala
+++ b/test/ApplicationSpec.scala
@@ -4,6 +4,7 @@ import org.junit.runner._
 
 import play.api.test._
 import play.api.test.Helpers._
+import play.api.libs.json._
 
 /**
  * Add your spec here.
@@ -26,5 +27,26 @@ class ApplicationSpec extends Specification {
       contentType(home) must beSome.which(_ == "text/html")
       contentAsString(home) must contain ("Welcome to SCOAP")
     }
+
+    "display a login screen" in new WithBrowser {
+      val action = route(FakeRequest(GET, "/login")).get
+      status(action) must equalTo(OK)
+      contentType(action) must beSome.which(_ == "text/html")
+      contentAsString(action) must contain ("Log in with MITID")
+    }
+
+//     "parse returned user json" in new WithBrowser {
+//       val action = route(
+//         FakeRequest(GET, "/_oauth-success")
+//           .withHeaders(CONTENT_TYPE -> "application/json")
+//           .withSession(("oauth-token", "asdffdsa"))
+//           .withBody("""
+// {"sub":"asdffdsa","name":"Some M User","preferred_username":"suser","given_name":"Some","family_name":"User","middle_name":"M","email":"suser@example.edu","email_verified":true}
+//             """)
+//         ).get
+//       status(action) must equalTo(OK)
+//       contentType(action) must beSome.which(_ == "application/json")
+//       contentAsString(action) must contain ("Log in with MITID")
+//     }
   }
 }

--- a/test/AuthenticationSpec.scala
+++ b/test/AuthenticationSpec.scala
@@ -1,0 +1,28 @@
+import org.specs2.mutable._
+import org.specs2.runner._
+import org.junit.runner._
+import org.specs2.mock._
+
+import play.api.test._
+import play.api.test.Helpers._
+import org.fest.assertions.Assertions.assertThat
+
+/**
+ * add your integration spec here.
+ * An integration test will fire up a whole play application in a real (or headless) browser
+ */
+class AuthenticationSpec extends Specification with Mockito {
+  "Application" should {
+    "display a login screen" in new WithBrowser {
+      browser.goTo("http://localhost:" + port + "/login")
+      browser.pageSource must contain("Log in with MITID")
+      assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+    }
+
+    "redirect when login is clicked" in new WithBrowser {
+      browser.goTo("http://localhost:" + port + "/login")
+      browser.$("#openid").click();
+      assertThat(browser.title()).isEqualTo("MIT OpenID Connect Pilot - Log In")
+    }
+  }
+}


### PR DESCRIPTION
This is an alternate example of authentication example for #127.

It doesn't use any libraries, and instead builds a client ourselves. On the plus side, this allows us to easily configure our app to use MIT's pilot authentication service. On the downside, there are likely error states and such we'll still need to build in support for that a public library may already handle for us.

What this does:
- if a user goes to `/login/` and clicks the `Sign In` link they'll be taken to MIT's login page where they can signin and choose what information to return to our app (we ask for 3 types of info but they can choose to NOT allow specific pieces so we'll need to present dialogs for things where they make sense... like maybe we insist they provide an email even though MIT allows them to restrict that form our app, etc).
- Once they are returned to our app, we request a token.
- We then use that token to get their profile information... and for now just dump it on the screen. We'd actually do some DB lookups, create accounts, whatever makes sense in our auth flow from here.

