### PR TITLE
Allows SWORD Url to be optional

### DIFF
--- a/app/models/ContentProfile.scala
+++ b/app/models/ContentProfile.scala
@@ -31,7 +31,7 @@ case class ContentProfile(id: Int, tag: String, label: String, description: Stri
     if (! schemes.contains(scheme)) {
       DB.withConnection { implicit c =>
         SQL("insert into content_profile_scheme (content_profile_id, scheme_id) values ({cprof_id}, {scheme_id})")
-        .on('cprof_id -> id, 'scheme_id -> scheme.id).executeInsert()
+        .on('cprof_id -> id, 'scheme_id -> scheme.id).executeUpdate()
       }
     }
   }

--- a/app/models/ResourceMap.scala
+++ b/app/models/ResourceMap.scala
@@ -53,8 +53,8 @@ case class ResourceMap(id: Int, tag: String, description: String, swordUrl: Opti
 object ResourceMap {
 
   val resmap = {
-    get[Int]("id") ~ get[String]("tag") ~ get[String]("description") ~ get[String]("sword_url") map {
-      case id ~ tag ~ description ~ swordUrl => ResourceMap(id, tag, description, Some(swordUrl))
+    get[Int]("id") ~ get[String]("tag") ~ get[String]("description") ~ get[Option[String]]("sword_url") map {
+      case id ~ tag ~ description ~ swordUrl => ResourceMap(id, tag, description, swordUrl)
     }
   }
 

--- a/test/unit/ResourceMapSpec.scala
+++ b/test/unit/ResourceMapSpec.scala
@@ -25,7 +25,7 @@ class ResourceMapSpec extends Specification {
         ResourceMap.create("tag", "desc", None)
         ResourceMap.all.size must equalTo(1)
       }
-    }.pendingUntilFixed("See https://github.com/MITLibraries/scoap3hub/issues/137")
+    }
 
     "#make" in {
       running(FakeApplication(additionalConfiguration = inMemoryDatabase())) {


### PR DESCRIPTION
Also reverts change in ContentProfile (insert -> update) method, which should only be used for Long DB
keys, according to Play documentation.
Fixes #137