### PR TITLE
Harvest Pages Roles

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -350,39 +350,34 @@ object Application extends Controller with Security {
     )(Scheme.apply)(Scheme.unapply)
   )
 
-  def schemes = Action { implicit request => //isAuthenticated { username => implicit request =>
-    //isAnalyst(/*username*/"richard", Ok(views.html.scheme_list(Scheme.all)))
+  def schemes = isAnalyst { identity => implicit request =>
     Ok(views.html.scheme.index(Scheme.all))
   }
 
-  def scheme(id: Int) = Action { implicit request =>
+  def scheme(id: Int) = isAnalyst { identity => implicit request =>
     Scheme.findById(id).map( scheme =>
       Ok(views.html.scheme.show(scheme))
     ).getOrElse(NotFound(views.html.static.trouble("No such scheme: " + id)))
   }
 
-  def newScheme = Action { implicit request => // isAuthenticated { username => implicit request =>
-     //isAnalyst(username, Ok(views.html.new_scheme(schemeForm)))
-     Ok(views.html.scheme.create(schemeForm))
+  def newScheme = isAnalyst { identity => implicit request =>
+    Ok(views.html.scheme.create(schemeForm))
   }
 
-  def editScheme(id: Int) = Action { implicit request => //isAuthenticated { username => implicit request =>
+  def editScheme(id: Int) = isAnalyst { identity => implicit request =>
     Scheme.findById(id).map( scheme =>
-      //isAnalyst(username, Ok(views.html.scheme_edit(scheme)))
       Ok(views.html.scheme.edit(scheme))
     ).getOrElse(NotFound(views.html.static.trouble("No such scheme: " + id)))
   }
 
-  def createScheme = Action { implicit request => //isAuthenticated { username => implicit request =>
-    //isAnalyst(username,
-      schemeForm.bindFromRequest.fold(
-        errors => BadRequest(views.html.scheme.create(errors)),
-        value => {
-          Scheme.create(value.tag, value.gentype, value.category, value.description, value.link, value.logo)
-          Redirect(routes.Application.schemes)
-        }
-      )
-    //)
+  def createScheme = isAnalyst { identity => implicit request =>
+    schemeForm.bindFromRequest.fold(
+      errors => BadRequest(views.html.scheme.create(errors)),
+      value => {
+        Scheme.create(value.tag, value.gentype, value.category, value.description, value.link, value.logo)
+        Redirect(routes.Application.schemes)
+      }
+    )
   }
 
   // content types

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -690,14 +690,13 @@ object Application extends Controller with Security {
     )(Validator.apply)(Validator.unapply)
   )
 
-  def newValidator(tag: String) = Action { implicit request => //isAuthenticated { username => implicit request =>
+  def newValidator(tag: String) = isAnalyst { identity => implicit request =>
     Scheme.findByTag(tag).map( scheme =>
-      //isAnalyst(username, Ok(views.html.new_validator(schemeId, validatorForm)))
       Ok(views.html.validator.create(tag, validatorForm))
     ).getOrElse(NotFound(views.html.static.trouble("Unknown scheme: " + tag)))
   }
 
-  def createValidator(tag: String) = Action { implicit request => //isAuthenticated { username => implicit request =>
+  def createValidator(tag: String) = isAnalyst { identity => implicit request =>
     Scheme.findByTag(tag).map( scheme =>
       validatorForm.bindFromRequest.fold(
         errors => BadRequest(views.html.validator.create(tag, errors)),
@@ -709,7 +708,7 @@ object Application extends Controller with Security {
     ).getOrElse(NotFound(views.html.static.trouble("Unknown scheme: " + tag)))
   }
 
-  def deleteValidator(tag: String, id: Int) = Action { implicit request => //isAuthenticated { username => implicit request =>
+  def deleteValidator(tag: String, id: Int) = isAnalyst { identity => implicit request =>
     Scheme.findByTag(tag).map( scheme => {
       Validator.delete(id)
       Ok(views.html.finder.index(Finder.findByScheme(scheme.id)))

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -643,20 +643,19 @@ object Application extends Controller with Security {
     )(Finder.apply)(Finder.unapply)
   )
 
-  def finders(tag: String) = Action { implicit request =>
+  def finders(tag: String) = isAnalyst { identity => implicit request =>
     Scheme.findByTag(tag).map( scheme =>
       Ok(views.html.finder.index(Finder.findByScheme(scheme.id)))
     ).getOrElse(NotFound(views.html.static.trouble("Unknown scheme: " + tag)))
   }
 
-  def newFinder(tag: String) = Action { implicit request => //isAuthenticated { username => implicit request =>
+  def newFinder(tag: String) = isAnalyst { identity => implicit request =>
     Scheme.findByTag(tag).map( scheme =>
-      //isAnalyst(username, Ok(views.html.new_finder(tag, finderForm)))
       Ok(views.html.finder.create(tag, finderForm))
     ).getOrElse(NotFound(views.html.static.trouble("Unknown scheme: " + tag)))
   }
 
-  def createFinder(tag: String) = Action { implicit request =>
+  def createFinder(tag: String) = isAnalyst { identity => implicit request =>
     Scheme.findByTag(tag).map( scheme =>
       finderForm.bindFromRequest.fold(
         errors => BadRequest(views.html.finder.create(tag, errors)),
@@ -669,7 +668,7 @@ object Application extends Controller with Security {
     ).getOrElse(NotFound(views.html.static.trouble("Unknown scheme: " + tag)))
   }
 
-  def deleteFinder(tag: String, id: Int) = Action { implicit request =>
+  def deleteFinder(tag: String, id: Int) = isAnalyst { identity => implicit request =>
     Scheme.findByTag(tag).map( scheme => {
       Finder.delete(id)
       Ok(views.html.finder.index(Finder.findByScheme(scheme.id)))

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -155,7 +155,11 @@ object Application extends Controller with Security {
 
   def publisher(id: Int) = Action { implicit request => {
     val user = if ( play.api.Play.isTest(play.api.Play.current) ) {
-        User.findById(1).get.identity
+        if (User.isValidIdentity("current_user")) {
+          User.findByIdentity("current_user").get.identity
+        } else {
+          ""
+        }
       } else {
         request.session.get("connected").getOrElse("")
       }

--- a/app/controllers/AuthenticationController.scala
+++ b/app/controllers/AuthenticationController.scala
@@ -57,8 +57,8 @@ trait Security {
       if (hasRole(user, "analyst")) {
         Action(request => f(user)(request))
       } else {
-        // todo: redirect to not authorzied page, not login page as that won't help
-        Action(request => Results.Redirect(routes.AuthenticationController.login))
+        Action(request =>
+          Results.Unauthorized(views.html.static.trouble("You are not authorized")))
       }
     }
   }

--- a/app/controllers/AuthenticationController.scala
+++ b/app/controllers/AuthenticationController.scala
@@ -38,7 +38,7 @@ trait Security {
         None
       }
     } else if ( play.api.Play.isTest(play.api.Play.current) ) {
-      User.findById(1)
+      User.findByIdentity("current_user")
     } else {
       None
     }

--- a/app/views/collection/create.scala.html
+++ b/app/views/collection/create.scala.html
@@ -14,7 +14,7 @@
           @inputText(collForm("tag"))
           @textarea(collForm("description"))
           @inputText(collForm("policy"))
-          <input type="submit" value="Create">
+          <input id="submit" type="submit" value="Create">
        }
       </div>
       <div class="col-md-8">

--- a/app/views/finder/create.scala.html
+++ b/app/views/finder/create.scala.html
@@ -14,6 +14,6 @@
     @inputText(finderForm("idKey"))
     @inputText(finderForm("idLabel"))
     @inputText(finderForm("author"))
-    <input type="submit" value="Create">
+    <input id="submit" type="submit" value="Create">
   }
 }

--- a/app/views/harvest/create.scala.html
+++ b/app/views/harvest/create.scala.html
@@ -13,6 +13,6 @@
         @inputText(harvestForm("resource_url"))
         @inputText(harvestForm("freq"))
         @inputDate(harvestForm("start"))
-        <input type="submit" value="Create">
+        <input id="submit" type="submit" value="Create">
     }
 }

--- a/app/views/scheme/create.scala.html
+++ b/app/views/scheme/create.scala.html
@@ -13,6 +13,6 @@
         @textarea(schemeForm("description"))
         @inputText(schemeForm("home"))
         @inputText(schemeForm("logo"))
-        <input type="submit" value="Create">
+        <input id="submit" type="submit" value="Create">
     }
 }

--- a/app/views/validator/create.scala.html
+++ b/app/views/validator/create.scala.html
@@ -14,6 +14,6 @@
     @inputText(valForm("serviceCode"))
     @inputText(valForm("serviceUrl"))
     @inputText(valForm("author"))
-    <input type="submit" value="Create">
+    <input id="submit" type="submit" value="Create">
   }
 }

--- a/test/ApplicationSpec.scala
+++ b/test/ApplicationSpec.scala
@@ -43,10 +43,11 @@ class ApplicationSpec extends Specification {
       redirectLocation(action) must beSome.which(_ == "/login")
     }
 
-    "display login screen when non analyst tries to access analyst protected page" in new WithApplication(FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+    "display error screen when non analyst tries to access analyst protected page" in new WithApplication(FakeApplication(additionalConfiguration = inMemoryDatabase())) {
       val user = create_user("schmuck")
       val action = route(FakeRequest(GET, "/workbench").withSession(("connected", user.identity))).get
-      redirectLocation(action) must beSome.which(_ == "/login")
+      redirectLocation(action) must beNone
+      contentAsString(action) must contain ("Reason: You are not authorized")
     }
 
     "display protected analyst page when analyst requests" in new WithApplication(FakeApplication(additionalConfiguration = inMemoryDatabase())) {

--- a/test/integration/AuthenticationPagesSpec.scala
+++ b/test/integration/AuthenticationPagesSpec.scala
@@ -41,8 +41,8 @@ class AuthenticationPageSpec extends Specification with Mockito {
       "deny access when signed in without analyst role" in new WithBrowser(app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         val user = create_user("schmuck")
         browser.goTo("http://localhost:" + port + "/workbench")
-        browser.pageSource must contain("Log in with your MIT ID")
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Error - TopicHub")
+        browser.pageSource must contain("You are not authorized")
       }
 
       "allow access when signed in with analyst role" in new WithBrowser(app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {

--- a/test/integration/AuthenticationPagesSpec.scala
+++ b/test/integration/AuthenticationPagesSpec.scala
@@ -15,7 +15,7 @@ import models.{ Harvest, Publisher, Subscriber, User }
  */
 class AuthenticationPageSpec extends Specification with Mockito {
 
-  def create_user(role: String) = User.make("bob", "bob@example.com", role, "identity")
+  def create_user(role: String) = User.make("bob", "bob@example.com", role, "current_user")
   def make_subscriber(userid: Int) = Subscriber.make(userid, "Sub Name", "cat", "contact", Some("link"), Some("logo"))
 
   "Application" should {

--- a/test/integration/CollectionPagesSpec.scala
+++ b/test/integration/CollectionPagesSpec.scala
@@ -1,0 +1,153 @@
+import org.specs2.mutable._
+import org.specs2.runner._
+
+import play.api.test._
+import play.api.test.Helpers._
+import org.fest.assertions.Assertions.assertThat
+import play.api.Application
+import play.api.Play
+import play.api.Play.current
+import models.{ Collection, ContentType, Harvest, Publisher, ResourceMap, User, Subscriber }
+
+/**
+ * An integration test will fire up a whole play application in a real (or headless) browser
+ */
+class CollectionPagesSpec extends Specification {
+
+  def create_user(role: String) = User.make("bob", "bob@example.com", role, "current_user")
+
+  "Collection pages" should {
+    "as an unauthenticated User" should {
+
+      // GET /collections
+      "accessing index is allowed" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val pub_user = User.make("pub", "pub@example.com", "some roles", "another_identity")
+        val pub = Publisher.make(pub_user.id, "pubtag", "pubname", "pubdesc", "pubcat",
+                                 "pubstatus", Some("http://www.example.com"), Some(""))
+        val ct = ContentType.make("tag", "label", "desc", Some("logo"))
+        val rm = ResourceMap.make("tag", "desc", Some("swordurl"))
+        var collection1 = Collection.make(pub.id, ct.id, rm.id, "coll1_tag", "coll1 desc", "open")
+        var collection2 = Collection.make(pub.id, ct.id, rm.id, "coll2_tag", "coll2 desc", "open")
+        browser.goTo("http://localhost:" + port + "/collections")
+        assertThat(browser.title()).isEqualTo("Collections - TopicHub")
+        browser.pageSource must contain(collection1.description)
+        browser.pageSource must contain(collection2.description)
+      }
+
+      // POST /publisher/:id
+      "posting to create redirects to login" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val pub_user = User.make("pub", "pub@example.com", "some roles", "another_identity")
+        val pub = Publisher.make(pub_user.id, "pubtag", "pubname", "pubdesc", "pubcat",
+                                 "pubstatus", Some("http://www.example.com"), Some(""))
+        val action = route(FakeRequest(POST, "/publisher/" + pub.id)).get
+        redirectLocation(action) must beSome.which(_ == "/login")
+        pub.collectionCount must equalTo(0)
+      }
+
+      // GET /publisher/:id/create
+      "accessing new collection form redirects to login" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val pub_user = User.make("pub", "pub@example.com", "some roles", "another_identity")
+        val pub = Publisher.make(pub_user.id, "pubtag", "pubname", "pubdesc", "pubcat",
+                                 "pubstatus", Some("http://www.example.com"), Some(""))
+        browser.goTo("http://localhost:" + port + "/publisher/" + pub.id + "/create")
+        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+      }
+    }
+
+    "as a User unaffiliated with the Publisher" should {
+
+      // GET /collections
+      "accessing index is allowed" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val user = create_user("somerole")
+        val pub_user = User.make("pub", "pub@example.com", "some roles", "another_identity")
+        val pub = Publisher.make(pub_user.id, "pubtag", "pubname", "pubdesc", "pubcat",
+                                 "pubstatus", Some("http://www.example.com"), Some(""))
+        val ct = ContentType.make("tag", "label", "desc", Some("logo"))
+        val rm = ResourceMap.make("tag", "desc", Some("swordurl"))
+        var collection1 = Collection.make(pub.id, ct.id, rm.id, "coll1_tag", "coll1 desc", "open")
+        var collection2 = Collection.make(pub.id, ct.id, rm.id, "coll2_tag", "coll2 desc", "open")
+        browser.goTo("http://localhost:" + port + "/collections")
+        assertThat(browser.title()).isEqualTo("Collections - TopicHub")
+        browser.pageSource must contain(collection1.description)
+        browser.pageSource must contain(collection2.description)
+      }
+
+      // POST /publisher/:id
+      "posting to create redirects to trouble" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val user = create_user("somerole")
+        val pub_user = User.make("pub", "pub@example.com", "some roles", "another_identity")
+        val pub = Publisher.make(pub_user.id, "pubtag", "pubname", "pubdesc", "pubcat",
+                                 "pubstatus", Some("http://www.example.com"), Some(""))
+        val action = route(FakeRequest(POST, "/publisher/" + pub.id)).get
+        redirectLocation(action) must beNone
+        contentAsString(action) must contain ("Reason: You are not authorized")
+        pub.collectionCount must equalTo(0)
+      }
+
+      // GET /publisher/:id/create
+      "accessing new collection form redirects to trouble" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val user = create_user("somerole")
+        val pub_user = User.make("pub", "pub@example.com", "some roles", "another_identity")
+        val pub = Publisher.make(pub_user.id, "pubtag", "pubname", "pubdesc", "pubcat",
+                                 "pubstatus", Some("http://www.example.com"), Some(""))
+        browser.goTo("http://localhost:" + port + "/publisher/" + pub.id + "/create")
+        assertThat(browser.title()).isEqualTo("Error - TopicHub")
+        browser.pageSource must contain("Reason: You are not authorized")
+      }
+    }
+
+    "as a User affiliated with the Publisher" should {
+
+      // GET /collections
+      "accessing index is allowed" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val user = create_user("somerole")
+        val pub = Publisher.make(user.id, "pubtag", "pubname", "pubdesc", "pubcat",
+                                 "pubstatus", Some("http://www.example.com"), Some(""))
+        val ct = ContentType.make("tag", "label", "desc", Some("logo"))
+        val rm = ResourceMap.make("tag", "desc", Some("swordurl"))
+        var collection1 = Collection.make(pub.id, ct.id, rm.id, "coll1_tag", "coll1 desc", "open")
+        var collection2 = Collection.make(pub.id, ct.id, rm.id, "coll2_tag", "coll2 desc", "open")
+        browser.goTo("http://localhost:" + port + "/collections")
+        assertThat(browser.title()).isEqualTo("Collections - TopicHub")
+        browser.pageSource must contain(collection1.description)
+        browser.pageSource must contain(collection2.description)
+      }
+
+      // POST /publisher/:id
+      "posting to create is allowed" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val user = create_user("somerole")
+        val pub = Publisher.make(user.id, "pubtag", "pubname", "pubdesc", "pubcat",
+                                 "pubstatus", Some("http://www.example.com"), Some(""))
+        val ct = ContentType.make("ct_tag_1", "ct_label_1", "desc", Some("logo"))
+        val rm = ResourceMap.make("rm_tag_1", "rm desc", Some("swordurl"))
+        browser.goTo("http://localhost:" + port + "/publisher/" + pub.id + "/create")
+        browser.$("#tag").text("collection_one_tag")
+        browser.$("#description").text("I'm a totally good description for a collection.")
+        browser.$("#policy").text("open access")
+        browser.$("#submit").click
+        pub.collectionCount must equalTo(1)
+        assertThat(browser.title()).isEqualTo("Publisher - TopicHub")
+        browser.pageSource must contain("totally good description")
+      }
+
+      // GET /publisher/:id/create
+      "accessing new collection form is allowed" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val user = create_user("somerole")
+        val pub = Publisher.make(user.id, "pubtag", "pubname", "pubdesc", "pubcat",
+                                 "pubstatus", Some("http://www.example.com"), Some(""))
+        browser.goTo("http://localhost:" + port + "/publisher/" + pub.id + "/create")
+        assertThat(browser.title()).isEqualTo("New Collection - TopicHub")
+        browser.pageSource must contain("Define a content collection")
+      }
+    }
+  }
+}

--- a/test/integration/DashboardPagesSpec.scala
+++ b/test/integration/DashboardPagesSpec.scala
@@ -14,7 +14,7 @@ import models.{ Harvest, Publisher, Subscriber, User }
  */
 class DashboardPagesSpec extends Specification with Mockito {
 
-  def create_user(role: String) = User.make("bob", "bob@example.com", role, "identity")
+  def create_user(role: String) = User.make("bob", "bob@example.com", role, "current_user")
   def make_subscriber(userid: Int) = Subscriber.make(userid, "Sub Name", "cat", "contact", Some("link"), Some("logo"))
 
   "The Dashboard" should {

--- a/test/integration/FinderPagesSpec.scala
+++ b/test/integration/FinderPagesSpec.scala
@@ -1,0 +1,168 @@
+import org.specs2.mutable._
+import org.specs2.runner._
+
+import play.api.test._
+import play.api.test.Helpers._
+import org.fest.assertions.Assertions.assertThat
+import play.api.Application
+import play.api.Play
+import play.api.Play.current
+import models.{ ContentFormat, Finder, User, Scheme }
+
+/**
+ * An integration test will fire up a whole play application in a real (or headless) browser
+ */
+class FinderPagesSpec extends Specification {
+
+  def create_user(role: String) = User.make("bob", "bob@example.com", role, "current_user")
+
+  "Finder pages" should {
+    "as an unauthenticated User" should {
+
+      // GET /scheme/:tag/finders
+      "accessing index redirects to login" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val s = Scheme.make("tag", "gentype", "cat", "desc", Some("link"), Some("logo"))
+        browser.goTo("http://localhost:" + port + "/scheme/" + s.tag + "/finders")
+        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+      }
+
+      // GET /scheme/:tag/create
+      "accessing new finder create form redirects to login" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val s = Scheme.make("tag", "gentype", "cat", "desc", Some("link"), Some("logo"))
+        browser.goTo("http://localhost:" + port + "/scheme/" + s.tag + "/create")
+        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+      }
+
+      // POST /scheme/:tag
+      "posting to finder create redirects to login" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val s = Scheme.make("tag", "gentype", "cat", "desc", Some("link"), Some("logo"))
+        val action = route(FakeRequest(POST, "/scheme/" + s.tag)).get
+        redirectLocation(action) must beSome.which(_ == "/login")
+        Finder.findByScheme(s.id).size must equalTo(0)
+      }
+
+      // GET /scheme/:tag/finder/:id/delete
+      "deleting finder redirects to login" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val s = Scheme.make("tag", "gentype", "cat", "desc", Some("link"), Some("logo"))
+        val cf = ContentFormat.make("tag", "label", "desc", "http://www.example.com", "mimetype", Some("logo"))
+        val f = Finder.make(s.id, cf.id, "description", "card", "idkey", "idlabel", "author")
+        Finder.findByScheme(s.id).size must equalTo(1)
+        browser.goTo("http://localhost:" + port + "/scheme/" + s.tag + "/finder/" + f.id + "/delete")
+        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        Finder.findByScheme(s.id).size must equalTo(1)
+      }
+    }
+
+    "as a User lacking the Analyst role" should {
+
+      // GET /scheme/:tag/finders
+      "accessing index redirects to trouble" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        create_user("somerole")
+        val s = Scheme.make("tag", "gentype", "cat", "desc", Some("link"), Some("logo"))
+        browser.goTo("http://localhost:" + port + "/scheme/" + s.tag + "/finders")
+        assertThat(browser.title()).isEqualTo("Error - TopicHub")
+        browser.pageSource must contain("You are not authorized")
+      }
+
+      // GET /scheme/:tag/create
+      "accessing new finder create form redirects to trouble" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        create_user("somerole")
+        val s = Scheme.make("tag", "gentype", "cat", "desc", Some("link"), Some("logo"))
+        browser.goTo("http://localhost:" + port + "/scheme/" + s.tag + "/create")
+        assertThat(browser.title()).isEqualTo("Error - TopicHub")
+        browser.pageSource must contain("You are not authorized")
+      }
+
+      // POST /scheme/:tag
+      "posting to finder create redirects to trouble" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        create_user("somerole")
+        val s = Scheme.make("tag", "gentype", "cat", "desc", Some("link"), Some("logo"))
+        val action = route(FakeRequest(POST, "/scheme/" + s.tag)).get
+        redirectLocation(action) must beNone
+        contentAsString(action) must contain ("Reason: You are not authorized")
+        Finder.findByScheme(s.id).size must equalTo(0)
+      }
+
+      // GET /scheme/:tag/finder/:id/delete
+      "deleting finder redirects to trouble" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        create_user("somerole")
+        val s = Scheme.make("tag", "gentype", "cat", "desc", Some("link"), Some("logo"))
+        val cf = ContentFormat.make("tag", "label", "desc", "http://www.example.com", "mimetype", Some("logo"))
+        val f = Finder.make(s.id, cf.id, "description", "card", "idkey", "idlabel", "author")
+        Finder.findByScheme(s.id).size must equalTo(1)
+        browser.goTo("http://localhost:" + port + "/scheme/" + s.tag + "/finder/" + f.id + "/delete")
+        assertThat(browser.title()).isEqualTo("Error - TopicHub")
+        browser.pageSource must contain("You are not authorized")
+        Finder.findByScheme(s.id).size must equalTo(1)
+      }
+    }
+
+    "as a User with the Analyst role" should {
+
+      // GET /scheme/:tag/finders
+      "accessing index displays finders" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        create_user("analyst")
+        val s = Scheme.make("tag", "gentype", "cat", "desc", Some("link"), Some("logo"))
+        browser.goTo("http://localhost:" + port + "/scheme/" + s.tag + "/finders")
+        assertThat(browser.title()).isEqualTo("Finders - TopicHub")
+        browser.pageSource must contain("Number of finders: 0")
+      }
+
+      // GET /scheme/:tag/create
+      "accessing new finder create form displays form" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        create_user("analyst")
+        val s = Scheme.make("tag", "gentype", "cat", "desc", Some("link"), Some("logo"))
+        browser.goTo("http://localhost:" + port + "/scheme/" + s.tag + "/create")
+        assertThat(browser.title()).isEqualTo("Create Finder - TopicHub")
+        browser.pageSource must contain(s"""<form action="/scheme/${s.tag}" method="POST">""")
+      }
+
+      // POST /scheme/:tag
+      "posting to finder create creates finder" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        create_user("analyst")
+        val s = Scheme.make("s_tag", "gentype", "cat", "desc", Some("link"), Some("logo"))
+        val cf1 = ContentFormat.make("cf_tag", "label", "desc", "http://www.example.com",
+                                     "mimetype", Some("logo"))
+        browser.goTo("http://localhost:" + port + "/scheme/" + s.tag + "/create")
+
+        // submission without filling out fields
+        browser.pageSource must not contain("This field is required")
+        browser.$("#submit").click
+        Finder.findByScheme(s.id).size must equalTo(0)
+        browser.pageSource must contain("This field is required")
+
+        // submission with valid fields
+        browser.$("#description").text("finder description")
+        browser.$("#cardinality").text("1")
+        browser.$("#idKey").text("//some/xpath/statement")
+        browser.$("#idLabel").text("No Label")
+        browser.$("#author").text("Not Me")
+        browser.$("#submit").click
+        Finder.findByScheme(s.id).size must equalTo(1)
+      }
+
+      // GET /scheme/:tag/finder/:id/delete
+      "deleting finder deletes finder" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        create_user("analyst")
+        val s = Scheme.make("tag", "gentype", "cat", "desc", Some("link"), Some("logo"))
+        val cf = ContentFormat.make("tag", "label", "desc", "http://www.example.com", "mimetype", Some("logo"))
+        val f = Finder.make(s.id, cf.id, "description", "card", "idkey", "idlabel", "author")
+        Finder.findByScheme(s.id).size must equalTo(1)
+        browser.goTo("http://localhost:" + port + "/scheme/" + s.tag + "/finder/" + f.id + "/delete")
+        Finder.findByScheme(s.id).size must equalTo(0)
+      }
+    }
+  }
+}

--- a/test/integration/HarvestPagesSpec.scala
+++ b/test/integration/HarvestPagesSpec.scala
@@ -1,0 +1,280 @@
+import org.specs2.mutable._
+import org.specs2.runner._
+import java.util.Date
+import play.api.test._
+import play.api.test.Helpers._
+import org.fest.assertions.Assertions.assertThat
+import play.api.Application
+import play.api.Play
+import play.api.Play.current
+import models.{ Collection, ContentType, Harvest, Publisher, ResourceMap, User, Subscriber }
+
+/**
+ * An integration test will fire up a whole play application in a real (or headless) browser
+ */
+class HarvestPagesSpec extends Specification {
+
+  def create_user(role: String) = User.make("bob", "bob@example.com", role, "current_user")
+  def make_subscriber(userid: Int) = Subscriber.make(userid, "Sub Name", "cat", "contact",
+                                                     Some("link"), Some("logo"))
+
+  "Harvest pages" should {
+    "as an unauthenticated User" should {
+      // GET /publisher/:id/createH
+      "accessing create form redirects to login" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val pub_user = User.make("pub", "pub@example.com", "some roles", "another_identity")
+        val pub = Publisher.make(pub_user.id, "pubtag", "pubname", "pubdesc", "pubcat",
+                                 "pubstatus", Some("http://www.example.com"), Some(""))
+        browser.goTo("http://localhost:" + port + "/publisher/" + pub.id + "/createH")
+        browser.pageSource must contain("Log in with your MIT ID")
+        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+      }
+
+      // POST /harvest/:id (publisher ID)
+      "posting to create redirects to login" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val pub_user = User.make("pub", "pub@example.com", "some roles", "another_identity")
+        val pub = Publisher.make(pub_user.id, "pubtag", "pubname", "pubdesc", "pubcat",
+                                 "pubstatus", Some("http://www.example.com"), Some(""))
+        val action = route(FakeRequest(POST, "/harvest/" + pub.id)).get
+        redirectLocation(action) must beSome.which(_ == "/login")
+        pub.harvestCount must equalTo(0)
+      }
+
+      // GET /harvest/:id
+      "viewing harvest page redirects to login" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val pub_user = User.make("pub", "pub@example.com", "some roles", "another_identity")
+        val pub = Publisher.make(pub_user.id, "pubtag", "pubname", "pubdesc", "pubcat",
+                                 "pubstatus", Some("http://www.example.com"), Some(""))
+        val harvest = Harvest.make(pub.id, "name", "protocol", "http://www.example.com",
+                                   "http://example.org", 1, new Date)
+        browser.goTo("http://localhost:" + port + "/harvest/" + harvest.id)
+        browser.pageSource must contain("Log in with your MIT ID")
+        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+      }
+
+      // GET /harvest/:id/start
+      "accessing harvest start page redirects to login" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val pub_user = User.make("pub", "pub@example.com", "some roles", "another_identity")
+        val pub = Publisher.make(pub_user.id, "pubtag", "pubname", "pubdesc", "pubcat",
+                                 "pubstatus", Some("http://www.example.com"), Some(""))
+        val harvest = Harvest.make(pub.id, "name", "protocol", "http://www.example.com",
+                                   "http://example.org", 1, new Date)
+        browser.goTo("http://localhost:" + port + "/harvest/" + harvest.id + "/start?span=1")
+        Harvest.findById(harvest.id).get.updated must equalTo(harvest.updated)
+        browser.pageSource must contain("Log in with your MIT ID")
+        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+      }
+
+      //GET /harvest/:id/delete
+      "accessing harvest delete redirects to login" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val pub_user = User.make("pub", "pub@example.com", "some roles", "another_identity")
+        val pub = Publisher.make(pub_user.id, "pubtag", "pubname", "pubdesc", "pubcat",
+                                 "pubstatus", Some("http://www.example.com"), Some(""))
+        val harvest = Harvest.make(pub.id, "name", "protocol", "http://www.example.com",
+                                   "http://example.org", 1, new Date)
+        browser.goTo("http://localhost:" + port + "/harvest/" + harvest.id + "/delete")
+        Harvest.findById(harvest.id).get must equalTo(harvest)
+        browser.pageSource must contain("Log in with your MIT ID")
+        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+      }
+
+      // GET /knip/:cid/:hid/:oid
+      "accessing harvest knip feature redirects to login" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val pub_user = User.make("pub", "pub@example.com", "some roles", "another_identity")
+        val pub = Publisher.make(pub_user.id, "pubtag", "pubname", "pubdesc", "pubcat",
+                                 "pubstatus", Some("http://www.example.com"), Some(""))
+        val harvest = Harvest.make(pub.id, "name", "protocol", "http://www.example.com",
+                                   "http://example.org", 1, new Date)
+        val ct = ContentType.make("tag", "label", "desc", Some("logo"))
+        val rm = ResourceMap.make("tag", "desc", Some("swordurl"))
+        var collection = Collection.make(pub.id, ct.id, rm.id, "coll", "desc", "open")
+        browser.goTo("http://localhost:" + port + "/knip/" + collection.id + "/" + harvest.id +
+                     "/scoap:asdf:fdsa")
+        browser.pageSource must contain("Log in with your MIT ID")
+        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+      }
+    }
+
+    "as a User unaffiliated with the Publisher" should {
+      // GET /publisher/:id/createH
+      "accessing create form redirects to trouble" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val user = create_user("norole")
+        val pub_user = User.make("pub", "pub@example.com", "some roles", "another_identity")
+        val pub = Publisher.make(pub_user.id, "pubtag", "pubname", "pubdesc", "pubcat",
+                                 "pubstatus", Some("http://www.example.com"), Some(""))
+        browser.goTo("http://localhost:" + port + "/publisher/" + pub.id + "/createH")
+        browser.pageSource must contain("Reason: You are not authorized")
+      }
+
+      // POST /harvest/:id (publisher ID)
+      "posting to create redirects to trouble" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val user = create_user("norole")
+        val pub_user = User.make("pub", "pub@example.com", "some roles", "another_identity")
+        val pub = Publisher.make(pub_user.id, "pubtag", "pubname", "pubdesc", "pubcat",
+                                 "pubstatus", Some("http://www.example.com"), Some(""))
+        val action = route(FakeRequest(POST, "/harvest/" + pub.id).withSession(("connected", user.identity))).get
+        redirectLocation(action) must beNone
+        contentAsString(action) must contain ("Reason: You are not authorized")
+        pub.harvestCount must equalTo(0)
+      }
+
+      // GET /harvest/:id
+      "viewing harvest page redirects to trouble" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val user = create_user("schmuck")
+        val pub_user = User.make("pub", "pub@example.com", "some roles", "another_identity")
+        val pub = Publisher.make(pub_user.id, "pubtag", "pubname", "pubdesc", "pubcat",
+                                 "pubstatus", Some("http://www.example.com"), Some(""))
+        val harvest = Harvest.make(pub.id, "name", "protocol", "http://www.example.com",
+                                   "http://example.org", 1, new Date)
+        browser.goTo("http://localhost:" + port + "/harvest/" + harvest.id)
+        browser.pageSource must contain("Reason: You are not authorized")
+      }
+
+      // GET /harvest/:id/start
+      "accessing harvest start page redirects to trouble" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val user = create_user("schmuck")
+        val pub_user = User.make("pub", "pub@example.com", "some roles", "another_identity")
+        val pub = Publisher.make(pub_user.id, "pubtag", "pubname", "pubdesc", "pubcat",
+                                 "pubstatus", Some("http://www.example.com"), Some(""))
+        val harvest = Harvest.make(pub.id, "name", "protocol", "http://www.example.com",
+                                   "http://example.org", 1, new Date)
+        browser.goTo("http://localhost:" + port + "/harvest/" + harvest.id + "/start?span=1")
+        Harvest.findById(harvest.id).get.updated must equalTo(harvest.updated)
+        browser.pageSource must contain("Reason: You are not authorized")
+      }
+
+      // GET /harvest/:id/delete
+      "accessing harvest delete redirects to trouble" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val user = create_user("schmuck")
+        val pub_user = User.make("pub", "pub@example.com", "some roles", "another_identity")
+        val pub = Publisher.make(pub_user.id, "pubtag", "pubname", "pubdesc", "pubcat",
+                                 "pubstatus", Some("http://www.example.com"), Some(""))
+        val harvest = Harvest.make(pub.id, "name", "protocol", "http://www.example.com",
+                                   "http://example.org", 1, new Date)
+        browser.goTo("http://localhost:" + port + "/harvest/" + harvest.id + "/delete")
+        Harvest.findById(harvest.id).get must equalTo(harvest)
+        browser.pageSource must contain("Reason: You are not authorized")
+      }
+
+      // GET /knip/:cid/:hid/:oid
+      "accessing harvest knip feature redirects to trouble" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val user = create_user("schmuck")
+        val pub_user = User.make("pub", "pub@example.com", "some roles", "another_identity")
+        val pub = Publisher.make(pub_user.id, "pubtag", "pubname", "pubdesc", "pubcat",
+                                 "pubstatus", Some("http://www.example.com"), Some(""))
+        val harvest = Harvest.make(pub.id, "name", "protocol", "http://www.example.com",
+                                   "http://example.org", 1, new Date)
+        val ct = ContentType.make("tag", "label", "desc", Some("logo"))
+        val rm = ResourceMap.make("tag", "desc", Some("swordurl"))
+        var collection = Collection.make(pub.id, ct.id, rm.id, "coll", "desc", "open")
+        browser.goTo("http://localhost:" + port + "/knip/" + collection.id + "/" + harvest.id +
+                     "/scoap:asdf:fdsa")
+        browser.pageSource must contain("Reason: You are not authorized")
+      }
+    }
+
+    "as a User affiliated with the Publisher" should {
+      // GET /publisher/:id/createH
+      "accessing create form succeeds" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val user = create_user("norole")
+        val pub = Publisher.make(user.id, "pubtag", "pubname", "pubdesc", "pubcat", "pubstatus",
+                                 Some("http://www.example.com"), Some(""))
+        browser.goTo("http://localhost:" + port + "/publisher/" + pub.id + "/createH")
+        assertThat(browser.title()).isEqualTo("Harvest - TopicHub")
+        browser.pageSource must contain("Define a content harvest")
+      }
+
+      // POST /harvest/:id (publisher ID)
+      "posting to create succeeds" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val user = create_user("norole")
+        val pub = Publisher.make(user.id, "pubtag", "pubname", "pubdesc", "pubcat", "pubstatus",
+                                 Some("http://www.example.com"), Some(""))
+        val pubHarvestCount = pub.harvestCount
+        browser.goTo("http://localhost:" + port + "/publisher/" + pub.id + "/createH")
+        browser.$("#name").text("harvest_name")
+        browser.$("#protocol").text("protocol")
+        browser.$("#service_url").text("http://www.example.com/oai2d")
+        browser.$("#resource_url").text("http://www.example.com/record/${recordId}/")
+        browser.$("#freq").text("1")
+        browser.$("#submit").click
+        browser.pageSource must contain("Valid date required")
+
+        browser.$("#start").text("2015-01-01")
+        browser.$("#submit").click
+        assertThat(browser.title()).isEqualTo("Publisher - TopicHub")
+        pub.harvestCount must equalTo(pubHarvestCount + 1)
+      }
+
+      // GET /harvest/:id
+      "viewing harvest page succeeds" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val user = create_user("schmuck")
+        val pub = Publisher.make(user.id, "pubtag", "pubname", "pubdesc", "pubcat", "pubstatus",
+                                 Some("http://www.example.com"), Some(""))
+        val harvest = Harvest.make(pub.id, "name", "protocol", "http://www.example.com",
+                                   "http://example.org", 1, new Date)
+        browser.goTo("http://localhost:" + port + "/harvest/" + harvest.id)
+        assertThat(browser.title()).isEqualTo("Harvest - TopicHub")
+        browser.pageSource must contain("""<form action="/harvest/1/start" method="GET">""")
+      }
+
+      // GET /harvest/:id/start
+      "accessing harvest start page succeeds" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val user = create_user("schmuck")
+        val pub = Publisher.make(user.id, "pubtag", "pubname", "pubdesc", "pubcat", "pubstatus",
+                                 Some("http://www.example.com"), Some(""))
+        val harvest = Harvest.make(pub.id, "name", "protocol", "http://www.example.com",
+                                   "http://example.org", 1, new Date)
+        browser.goTo("http://localhost:" + port + "/harvest/" + harvest.id + "/start?span=1")
+        Harvest.findById(harvest.id).get.updated.toInstant must equalTo(harvest.updated.toInstant.plusSeconds(86400))
+        assertThat(browser.title()).isEqualTo("Harvest - TopicHub")
+        browser.pageSource must contain("""<form action="/harvest/1/start" method="GET">""")
+      }
+
+      //GET /harvest/:id/delete
+      "accessing harvest delete succeeds" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val user = create_user("schmuck")
+        val pub = Publisher.make(user.id, "pubtag", "pubname", "pubdesc", "pubcat", "pubstatus",
+                                 Some("http://www.example.com"), Some(""))
+        val harvest = Harvest.make(pub.id, "name", "protocol", "http://www.example.com",
+                                   "http://example.org", 1, new Date)
+        browser.goTo("http://localhost:" + port + "/harvest/" + harvest.id + "/delete")
+        Harvest.findById(harvest.id) must equalTo(None)
+        assertThat(browser.title()).isEqualTo("Publisher - TopicHub")
+        browser.pageSource must contain("/publisher/1/edit")
+      }
+
+      // GET /knip/:cid/:hid/:oid
+      "accessing harvest knip feature succeeds" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val user = create_user("schmuck")
+        val pub = Publisher.make(user.id, "pubtag", "pubname", "pubdesc", "pubcat", "pubstatus",
+                                 Some("http://www.example.com"), Some(""))
+        val harvest = Harvest.make(pub.id, "name", "protocol", "http://www.example.com",
+                                   "http://example.org", 1, new Date)
+        val ct = ContentType.make("tag", "label", "desc", Some("logo"))
+        val rm = ResourceMap.make("tag", "desc", Some("swordurl"))
+        var collection = Collection.make(pub.id, ct.id, rm.id, "coll", "desc", "open")
+        browser.goTo("http://localhost:" + port + "/knip/" + collection.id + "/" + harvest.id +
+                     "/scoap:asdf:fdsa")
+        assertThat(browser.title()).isEqualTo("TopicHub")
+      }
+    }
+  }
+}

--- a/test/integration/IntegrationSpec.scala
+++ b/test/integration/IntegrationSpec.scala
@@ -40,7 +40,8 @@ class IntegrationSpec extends Specification {
       browser.goTo("http://localhost:" + port)
       browser.$("body > nav > div > div.navbar-header > button").click();
       browser.$("a[href*='workbench']").click();
-      assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+      assertThat(browser.title()).isEqualTo("Error - TopicHub")
+      browser.pageSource must contain("You are not authorized")
     }
 
     "top navigation should deny Workbench access to not logged in user" in new WithBrowser(app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {

--- a/test/integration/IntegrationSpec.scala
+++ b/test/integration/IntegrationSpec.scala
@@ -17,7 +17,7 @@ import play.api.Play.current
 @RunWith(classOf[JUnitRunner])
 class IntegrationSpec extends Specification {
 
-  def create_user(role: String) = User.make("bob", "bob@example.com", role, "identity")
+  def create_user(role: String) = User.make("bob", "bob@example.com", role, "current_user")
 
   "Application" should {
     "work from within a browser" in new WithBrowser(app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {

--- a/test/integration/SchemePagesSpec.scala
+++ b/test/integration/SchemePagesSpec.scala
@@ -1,0 +1,179 @@
+import org.specs2.mutable._
+import org.specs2.runner._
+
+import play.api.test._
+import play.api.test.Helpers._
+import org.fest.assertions.Assertions.assertThat
+import play.api.Application
+import play.api.Play
+import play.api.Play.current
+import models.{ User, Scheme }
+
+/**
+ * An integration test will fire up a whole play application in a real (or headless) browser
+ */
+class SchemePagesSpec extends Specification {
+
+  def create_user(role: String) = User.make("bob", "bob@example.com", role, "current_user")
+
+  "Scheme pages" should {
+    "as an unauthenticated User" should {
+
+      // GET /schemes
+      "accessing index redirects to login" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        browser.goTo("http://localhost:" + port + "/schemes")
+        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+      }
+
+      // GET /scheme/:id
+      "viewing scheme redirects to login" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val s1 = Scheme.make("s1_tag", "gentype", "cat", "s1_desc", Some("link"), Some("logo"))
+        browser.goTo("http://localhost:" + port + "/scheme/" + s1.id)
+        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+      }
+
+      // GET /scheme/:id/edit
+      "accessing edit scheme form redirects to login" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val s1 = Scheme.make("s1_tag", "gentype", "cat", "s1_desc", Some("link"), Some("logo"))
+        browser.goTo("http://localhost:" + port + "/scheme/" + s1.id + "/edit")
+        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+      }
+
+      // GET /schemes/create
+      "accessing new scheme create form redirects to login" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        browser.goTo("http://localhost:" + port + "/schemes/create")
+        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+      }
+
+      // POST /schemes
+      "posting to scheme create redirects to login" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val action = route(FakeRequest(POST, "/schemes")).get
+        redirectLocation(action) must beSome.which(_ == "/login")
+        Scheme.all.size must equalTo(0)
+      }
+    }
+
+    "as a User lacking the Analyst role" should {
+
+      // GET /schemes
+      "accessing index redirects to trouble" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        create_user("somerole")
+        browser.goTo("http://localhost:" + port + "/schemes")
+        assertThat(browser.title()).isEqualTo("Error - TopicHub")
+        browser.pageSource must contain("You are not authorized")
+      }
+
+      // GET /scheme/:id
+      "viewing scheme redirects to trouble" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        create_user("somerole")
+        val s1 = Scheme.make("s1_tag", "gentype", "cat", "s1_desc", Some("link"), Some("logo"))
+        browser.goTo("http://localhost:" + port + "/scheme/" + s1.id)
+        assertThat(browser.title()).isEqualTo("Error - TopicHub")
+        browser.pageSource must contain("You are not authorized")
+      }
+
+      // GET /scheme/:id/edit
+      "accessing edit scheme form redirects to trouble" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        create_user("somerole")
+        val s1 = Scheme.make("s1_tag", "gentype", "cat", "s1_desc", Some("link"), Some("logo"))
+        browser.goTo("http://localhost:" + port + "/scheme/" + s1.id + "/edit")
+        assertThat(browser.title()).isEqualTo("Error - TopicHub")
+        browser.pageSource must contain("You are not authorized")
+      }
+
+      // GET /schemes/create
+      "accessing new scheme create form redirects to trouble" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        create_user("somerole")
+        browser.goTo("http://localhost:" + port + "/schemes/create")
+        assertThat(browser.title()).isEqualTo("Error - TopicHub")
+        browser.pageSource must contain("You are not authorized")
+      }
+
+      // POST /schemes
+      "posting to scheme create redirects to trouble" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        create_user("somerole")
+        val action = route(FakeRequest(POST, "/schemes")).get
+        redirectLocation(action) must beNone
+        contentAsString(action) must contain ("Reason: You are not authorized")
+        Scheme.all.size must equalTo(0)
+      }
+    }
+
+    "as a User with the Analyst role" should {
+
+      // GET /schemes
+      "accessing index displays schemes" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val user = create_user("analyst")
+        val s1 = Scheme.make("scheme_1_tag", "gentype", "cat", "scheme_1 description",
+                             Some("link"), Some("logo"))
+        val s2 = Scheme.make("scheme_2_tag", "gentype", "cat", "scheme_2 description",
+                             Some("link"), Some("logo"))
+
+        browser.goTo("http://localhost:" + port + "/schemes")
+        assertThat(browser.title()).isEqualTo("Schemes - TopicHub")
+        browser.pageSource must contain(s1.description)
+        browser.pageSource must contain(s2.description)
+      }
+
+      // GET /scheme/:id
+      "viewing scheme displays scheme" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val user = create_user("analyst")
+        val s1 = Scheme.make("s1_tag", "gentype", "cat", "s1_desc", Some("link"), Some("logo"))
+        browser.goTo("http://localhost:" + port + "/scheme/" + s1.id)
+        assertThat(browser.title()).isEqualTo("Scheme - TopicHub")
+        browser.pageSource must contain(s1.description)
+        browser.pageSource must contain("manage scheme")
+        browser.pageSource must contain("No topics")
+      }
+
+      // GET /scheme/:id/edit
+      "accessing edit scheme displays scheme edit view" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        create_user("analyst")
+        val s1 = Scheme.make("s1_tag", "gentype", "cat", "s1_desc", Some("link"), Some("logo"))
+        browser.goTo("http://localhost:" + port + "/scheme/" + s1.id + "/edit")
+        assertThat(browser.title()).isEqualTo("Scheme - TopicHub")
+        browser.pageSource must contain("New Validator")
+        browser.pageSource must contain("New Finder")
+      }
+
+      // GET /schemes/create
+      "accessing new scheme create form displays form" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        create_user("analyst")
+        browser.goTo("http://localhost:" + port + "/schemes/create")
+        assertThat(browser.title()).isEqualTo("Create Scheme - TopicHub")
+        browser.pageSource must contain("""<form action="/schemes" method="POST">""")
+      }
+
+      // POST /schemes
+      "posting to scheme create creates scheme" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        create_user("analyst")
+        browser.goTo("http://localhost:" + port + "/schemes/create")
+        browser.$("#tag").text("scheme_one_tag")
+        browser.$("#description").text("I'm a totally good description for a scheme.")
+        browser.$("#category").text("scheme cat")
+        browser.$("#gentype").text("scheme gentype")
+        browser.$("#home").text("http://www.example.com")
+        browser.$("#logo").text("http://www.example.com/icon.png")
+        browser.$("#submit").click
+        assertThat(browser.title()).isEqualTo("Schemes - TopicHub")
+        browser.pageSource must contain("totally good description")
+        Scheme.all.size must equalTo(1)
+      }
+    }
+  }
+}

--- a/test/integration/ValidatorPagesSpec.scala
+++ b/test/integration/ValidatorPagesSpec.scala
@@ -1,0 +1,145 @@
+import org.specs2.mutable._
+import org.specs2.runner._
+
+import play.api.test._
+import play.api.test.Helpers._
+import org.fest.assertions.Assertions.assertThat
+import play.api.Application
+import play.api.Play
+import play.api.Play.current
+import models.{ Scheme, User, Validator }
+
+/**
+ * An integration test will fire up a whole play application in a real (or headless) browser
+ */
+class ValidatorPagesSpec extends Specification {
+
+  def create_user(role: String) = User.make("bob", "bob@example.com", role, "current_user")
+
+  "Validator pages" should {
+    "as an unauthenticated User" should {
+
+      // GET /scheme/:tag/createvalidator
+      "accessing new validator form redirects to login" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val s = Scheme.make("s1_tag", "gentype", "cat", "s1_desc", Some("link"), Some("logo"))
+        browser.goTo("http://localhost:" + port + "/scheme/" + s.tag + "/createvalidator")
+        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+      }
+
+      // POST /scheme/:tag/validator
+      "posting to validator create redirects to login" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val s = Scheme.make("s1_tag", "gentype", "cat", "s1_desc", Some("link"), Some("logo"))
+        val action = route(FakeRequest(POST, "/scheme/" + s.tag + "/validator")).get
+        redirectLocation(action) must beSome.which(_ == "/login")
+        Validator.findByScheme(s.id).size must equalTo(0)
+      }
+
+      // GET /scheme/:tag/validator/:id/delete
+      "calling delete validator redirects to login" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val s = Scheme.make("s1_tag", "gentype", "cat", "s1_desc", Some("link"), Some("logo"))
+        Validator.create(s.id, "desc", "user", "pass", "servicecode", "serviceurl", "someone")
+        val v = Validator.findByScheme(s.id).head
+        Validator.findByScheme(s.id).size must equalTo(1)
+        browser.goTo("http://localhost:" + port + "/scheme/" + s.tag + "/validator/" + v.id +
+                     "/delete")
+        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        Validator.findByScheme(s.id).size must equalTo(1)
+      }
+    }
+
+    "as a User lacking the Analyst role" should {
+
+      // GET /scheme/:tag/createvalidator
+      "accessing new validator form redirects to trouble" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        create_user("somerole")
+        val s = Scheme.make("s1_tag", "gentype", "cat", "s1_desc", Some("link"), Some("logo"))
+        browser.goTo("http://localhost:" + port + "/scheme/" + s.tag + "/createvalidator")
+        assertThat(browser.title()).isEqualTo("Error - TopicHub")
+        browser.pageSource must contain("You are not authorized")
+      }
+
+      // POST /scheme/:tag/validator
+      "posting to validator create redirects to trouble" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        create_user("somerole")
+        val s = Scheme.make("s1_tag", "gentype", "cat", "s1_desc", Some("link"), Some("logo"))
+        val action = route(FakeRequest(POST, "/scheme/" + s.tag + "/validator")).get
+        redirectLocation(action) must beNone
+        contentAsString(action) must contain ("Reason: You are not authorized")
+        Validator.findByScheme(s.id).size must equalTo(0)
+      }
+
+      // GET /scheme/:tag/validator/:id/delete
+      "calling delete validator redirects to trouble" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        create_user("somerole")
+        val s = Scheme.make("s1_tag", "gentype", "cat", "s1_desc", Some("link"), Some("logo"))
+        Validator.create(s.id, "desc", "user", "pass", "servicecode", "serviceurl", "someone")
+        val v = Validator.findByScheme(s.id).head
+        Validator.findByScheme(s.id).size must equalTo(1)
+        browser.goTo("http://localhost:" + port + "/scheme/" + s.tag + "/validator/" + v.id +
+                     "/delete")
+        assertThat(browser.title()).isEqualTo("Error - TopicHub")
+        browser.pageSource must contain("You are not authorized")
+        Validator.findByScheme(s.id).size must equalTo(1)
+      }
+    }
+
+    "as a User with the Analyst role" should {
+
+      // GET /scheme/:tag/createvalidator
+      "accessing new validator form displays form" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        create_user("analyst")
+        val s = Scheme.make("s1_tag", "gentype", "cat", "s1_desc", Some("link"), Some("logo"))
+        browser.goTo("http://localhost:" + port + "/scheme/" + s.tag + "/createvalidator")
+        assertThat(browser.title()).isEqualTo("Create Validator - TopicHub")
+        browser.pageSource must contain(
+          s"""<form action="/scheme/${s.tag}/validator" method="POST">""")
+      }
+
+      // POST /scheme/:tag/validator
+      "posting to validator create creates a validator" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        create_user("analyst")
+        val s = Scheme.make("s1_tag", "gentype", "cat", "s1_desc", Some("link"), Some("logo"))
+        browser.goTo("http://localhost:" + port + "/scheme/" + s.tag + "/createvalidator")
+
+        // submit without required fields
+        browser.pageSource must not contain("This field is required")
+        browser.$("#submit").click
+        browser.pageSource must contain("This field is required")
+        Validator.findByScheme(s.id).size must equalTo(0)
+
+        // fill out form
+        browser.$("#description").text("I'm a totally good description for a validator")
+        browser.$("#userId").text("user")
+        browser.$("#password").text("password")
+        browser.$("#serviceCode").text("some code")
+        browser.$("#serviceUrl").text("http://www.example.com")
+        browser.$("#author").text("not me")
+        browser.$("#submit").click
+        assertThat(browser.title()).isEqualTo("Finders - TopicHub")
+        Validator.findByScheme(s.id).size must equalTo(1)
+      }
+
+      // GET /scheme/:tag/validator/:id/delete
+      "calling delete validator deletes the validator" in new WithBrowser(
+        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        create_user("analyst")
+        val s = Scheme.make("s1_tag", "gentype", "cat", "s1_desc", Some("link"), Some("logo"))
+        Validator.create(s.id, "desc", "user", "pass", "servicecode", "serviceurl", "someone")
+        val v = Validator.findByScheme(s.id).head
+        Validator.findByScheme(s.id).size must equalTo(1)
+        browser.goTo("http://localhost:" + port + "/scheme/" + s.tag + "/validator/" + v.id +
+                     "/delete")
+        assertThat(browser.title()).isEqualTo("Finders - TopicHub")
+        Validator.findByScheme(s.id).size must equalTo(0)
+      }
+    }
+  }
+}


### PR DESCRIPTION
https://github.com/MITLibraries/scoap3hub/compare/128_roles?expand=1#diff-d329b37da40ee3da83671939b016c05fR41 allows Integration Tests for non-authenticated users to run with tests that logically require existing users by have the current test user use a specific Identity value instead of Id = 1.

Primarily harvest page specs, but also includes Publisher Page Specs that were not possible until the above Test ENV user logic change was made.