### PR TITLE
Switch to old Travis infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ scala:
  - "2.11.6"
 jdk:
  - oraclejdk8
-sudo: false
+sudo: required
 env:
   - MAILGUN_API_KEY=notarealkey DATABASE_URL=jdbc:postgresql://localhost/travis_ci_test
 addons:


### PR DESCRIPTION
This will hopefully allow us to leave fork in Test on while still getting stable Travis builds. There is a ticket referenced in the commit that will hopefully get resolved so we can switch back eventually (this may also not really fix anything. We'll see over time).