### PR TITLE
Test new travis platform again

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,0 +1,3 @@
+-J-Xmx2048M
+-J-XX:MaxMetaspaceSize=512M
+-J-XX:+CMSClassUnloadingEnabled

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,24 @@ scala:
  - "2.11.6"
 jdk:
  - oraclejdk8
-sudo: required
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot/
+
 env:
   - MAILGUN_API_KEY=notarealkey DATABASE_URL=jdbc:postgresql://localhost/travis_ci_test
 addons:
-  postgresql: "9.3"
-script: "sbt clean coverage test"
+  postgresql: "9.4"
+script:
+  - sbt ++$TRAVIS_SCALA_VERSION -J-XX:ReservedCodeCacheSize=256M coverage test
+  # Tricks to avoid unnecessary cache updates
+  - find $HOME/.sbt -name "*.lock" | xargs rm
+  - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
+
 after_success: "sbt coveralls"
+before_script:
 before_script:
   - psql -c 'create database travis_ci_test;' -U postgres

--- a/build.sbt
+++ b/build.sbt
@@ -22,4 +22,4 @@ libraryDependencies ++= Seq(
 )
 
 parallelExecution in Test := false
-fork in Test := true
+fork in Test := false


### PR DESCRIPTION
Switching back to the new Travis platform with `sudo: false`.

Fork in Test:
I believe I am avoiding the issues I ran into locally without forking
for tests by increasing MaxMetaspaceSize. For now, I have includes settings
in project root .sbtopts that work for me. I can remove that from the repo
and only use that locally if it seems others may want different settings.

Also:
— cache ivy2/cache for faster builds on Travis!
— sets -J-XX:ReservedCodeCacheSize=256M but I don't think this mattered (or hurts though).