### PR TITLE
Method to expose Items with no Topics

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -260,6 +260,11 @@ object Application extends Controller with Security {
              val harv = harvest.copy(freq = value)
              harvester ! harv
              // optimistically update - so UI will show last harvest date
+
+             // todo: while appropriate to update the UI immediately, we need a way to determine
+             // whether the harvest was able to grabe a list of new items and create the Item
+             // records. If we don't protect for that it's possible we could miss entire days
+             // worth of Items and never know.
              harv.complete
              Redirect(routes.Application.harvest(id))
           }

--- a/app/controllers/ItemController.scala
+++ b/app/controllers/ItemController.scala
@@ -41,6 +41,11 @@ object ItemController extends Controller with Security {
     ).getOrElse(NotFound(views.html.static.trouble("No such collection")))
   }
 
+  def itemsWithNoTopics = isAdmin { identity => { implicit request =>
+      Ok(views.html.item.notopics(Item.allMissingMetadata))
+    }
+  }
+
   def itemMets(id: Int) = Action { implicit request =>
     Item.findById(id).map( item =>
       Ok(item.toMets)

--- a/app/models/Harvest.scala
+++ b/app/models/Harvest.scala
@@ -47,6 +47,17 @@ case class Harvest(id: Int,             // DB key
       .on('updated -> newDate, 'id -> id).executeUpdate()
     }
   }
+
+  def harvestUrl = {
+    // OAI-PMH date filters are inclusive on both ends (from and until),
+    // so same from and until = 1 day. Thus a harvest starts from 1 day
+    // past the last updated date thru freqency - 1 additional days (clear as mud?)
+    val from = HubUtils.advanceDate(updated, 1)
+    val until = HubUtils.advanceDate(from, freq - 1)
+    serviceUrl + "?verb=ListIdentifiers&metadataPrefix=oai_dc" +
+                 "&from=" + HubUtils.fmtDate(from) +
+                 "&until=" + HubUtils.fmtDate(until)
+  }
 }
 
 object Harvest {

--- a/app/models/Item.scala
+++ b/app/models/Item.scala
@@ -283,6 +283,17 @@ object Item {
     }
   }
 
+  def allMissingMetadata: List[Item] = {
+    DB.withConnection { implicit c =>
+      SQL("""
+              SELECT item.*
+              FROM item
+              LEFT JOIN item_topic on item.id = item_topic.id
+              WHERE item_topic.id IS NULL
+          """).as(item *)
+    }
+  }
+
   def findByKey(key: String): Option[Item] = {
     DB.withConnection { implicit c =>
       SQL("select * from item where obj_key = {key}").on('key -> key).as(item.singleOpt)

--- a/app/views/item/notopics.scala.html
+++ b/app/views/item/notopics.scala.html
@@ -1,0 +1,22 @@
+@*****************************************************************************
+ * Page to display Items missing Topics (which is an error state)            *
+ * Copyright (c) 2015 MIT Libraries                                          *
+ *****************************************************************************@
+ @(items: List[Item])(implicit request: play.api.mvc.RequestHeader)
+
+@layout.main("Items missing Topics -  TopicHub") {
+  <div class="page-header">
+    <h2>Items missing Topics</h2>
+    <p>These items are in an error state as all Items should have at least
+    one topic assigned by a successful cataloger worker.</p>
+    <p>At this time we have no method to clean up these records from this interface.
+    Once we know what likely steps we should take, we can add that.</p>
+  </div>
+  <ul>
+    @items.map { item =>
+      <li>
+        <a href="@routes.ItemController.item(item.id)">@Html(item.metadataValue("title"))</a>
+      </li>
+   }
+  </ul>
+}

--- a/app/views/static/workbench.scala.html
+++ b/app/views/static/workbench.scala.html
@@ -15,6 +15,9 @@
             <a id="sidenav_models" href="@routes.Application.newHubModel" class="list-group-item">
               Models
             </a>
+
+            <a id="sidenav_notopic_items" href="@routes.ItemController.itemsWithNoTopics" class="list-group-item">
+            Items with no Topics <span class="badge">@{ Item.allMissingMetadata.size }</span></a>
           }
 
           <a id="sidenav_schemes" href="@routes.Application.schemes" class="list-group-item">Schemes</a>

--- a/conf/routes
+++ b/conf/routes
@@ -98,6 +98,7 @@ GET     /item/:id                    controllers.ItemController.item(id: Int)
 GET     /item/package/:id            controllers.ItemController.itemPackage(id: Int)
 GET     /item/deposit/:id            controllers.ItemController.itemDeposit(id: Int)
 GET     /item/mets/:id               controllers.ItemController.itemMets(id: Int)
+GET     /items/missingtopics         controllers.ItemController.itemsWithNoTopics
 
 # Topic pages
 GET     /topics                      controllers.Application.topics

--- a/test/integration/WorkbenchPagesSpec.scala
+++ b/test/integration/WorkbenchPagesSpec.scala
@@ -63,6 +63,16 @@ class WorkbenchPagesSpec extends Specification {
       browser.$("#sidenav_models").click
       assertThat(browser.title()).isEqualTo("Create Model - TopicHub")
     }
+
+    "provides link to items with no topics" in new WithBrowser(app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+      val user = create_user("sysadmin, analyst")
+      browser.goTo("http://localhost:" + port + "/login")
+      browser.$("#openid").click
+      browser.goTo("http://localhost:" + port + "/workbench")
+      browser.pageSource must contain("""<a id="sidenav_notopic_items" href="/items/missingtopics""")
+      browser.$("#sidenav_notopic_items").click
+      assertThat(browser.title()).isEqualTo("Items missing Topics - TopicHub")
+    }
   }
 
   "Workbench for analysts" should {
@@ -84,6 +94,14 @@ class WorkbenchPagesSpec extends Specification {
       browser.goTo("http://localhost:" + port + "/model/create")
       assertThat(browser.title()).isEqualTo("Error - TopicHub")
       browser.pageSource must contain("You are not authorized")
+    }
+
+    "does not provide link to items with no topics" in new WithBrowser(app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+      val user = create_user("analyst")
+      browser.goTo("http://localhost:" + port + "/login")
+      browser.$("#openid").click
+      browser.goTo("http://localhost:" + port + "/workbench")
+      browser.pageSource must not contain("""<a id="sidenav_notopic_items" href="/items/missingtopics""")
     }
 
     "provides link to Schemes" in new WithBrowser(app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {


### PR DESCRIPTION
Items with no Topics is a sign of an error state in the Cataloger as it
should always assign either Any or None topics.

This should help us identify Items where the Cataloging failed and thus
determine what next steps to take.

Closes #69