### PR TITLE
Method to expose Items with no Topics

### DIFF
--- a/app/controllers/ItemController.scala
+++ b/app/controllers/ItemController.scala
@@ -41,6 +41,11 @@ object ItemController extends Controller with Security {
     ).getOrElse(NotFound(views.html.static.trouble("No such collection")))
   }
 
+  def itemsWithNoTopics = isAdmin { identity => { implicit request =>
+      Ok(views.html.item.notopics(Item.allMissingMetadata))
+    }
+  }
+
   def itemMets(id: Int) = Action { implicit request =>
     Item.findById(id).map( item =>
       Ok(item.toMets)

--- a/app/models/HubUtils.scala
+++ b/app/models/HubUtils.scala
@@ -23,7 +23,12 @@ object HubUtils {
   val iso8601 = DateTimeFormatter.ISO_LOCAL_DATE
 
   def fmtDate(date: Date) = {
-      date.toInstant.atZone(ZoneId.systemDefault).toLocalDate.format(iso8601)
+    date.toInstant.atZone(ZoneId.systemDefault).toLocalDate.format(iso8601)
+  }
+
+  def fmtPreciseDateTime(date: Date) = {
+    val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss:SSS");
+    date.toInstant.atZone(ZoneId.systemDefault).toLocalDateTime.format(formatter)
   }
 
   def advanceDate(curDate: Date, days: Int): Date = {

--- a/app/models/Item.scala
+++ b/app/models/Item.scala
@@ -283,6 +283,18 @@ object Item {
     }
   }
 
+  def allMissingMetadata: List[Item] = {
+    DB.withConnection { implicit c =>
+      SQL("""
+              SELECT item.*
+              FROM item
+              LEFT JOIN item_topic on item.id = item_topic.item_id
+              WHERE item_topic.id IS NULL
+              ORDER BY created DESC
+          """).as(item *)
+    }
+  }
+
   def findByKey(key: String): Option[Item] = {
     DB.withConnection { implicit c =>
       SQL("select * from item where obj_key = {key}").on('key -> key).as(item.singleOpt)

--- a/app/views/item/notopics.scala.html
+++ b/app/views/item/notopics.scala.html
@@ -1,0 +1,24 @@
+@*****************************************************************************
+ * Page to display Items missing Topics (which is an error state)            *
+ * Copyright (c) 2015 MIT Libraries                                          *
+ *****************************************************************************@
+ @(items: List[Item])(implicit request: play.api.mvc.RequestHeader)
+
+@layout.main("Items missing Topics -  TopicHub") {
+  <div class="page-header">
+    <h2>Items missing Topics</h2>
+    <p>These items are in an error state as all Items should have at least
+    one topic assigned by a successful cataloger worker.</p>
+    <p>At this time we have no method to clean up these records from this interface.
+    Once we know what likely steps we should take, we can add that.</p>
+  </div>
+  <ul class="list-group">
+    @items.map { item =>
+      <li class="list-group-item">
+        @HubUtils.fmtPreciseDateTime(item.created)
+        <a href="@routes.ItemController.item(item.id)">View Local record</a>
+        <a href="@item.location.substring(7)">View Remote Record</a>
+      </li>
+   }
+  </ul>
+}

--- a/app/views/static/workbench.scala.html
+++ b/app/views/static/workbench.scala.html
@@ -15,6 +15,9 @@
             <a id="sidenav_models" href="@routes.Application.newHubModel" class="list-group-item">
               Models
             </a>
+
+            <a id="sidenav_notopic_items" href="@routes.ItemController.itemsWithNoTopics" class="list-group-item">
+            Items with no Topics <span class="badge">@{ Item.allMissingMetadata.size }</span></a>
           }
 
           <a id="sidenav_schemes" href="@routes.Application.schemes" class="list-group-item">Schemes</a>

--- a/app/workers/Harvester.scala
+++ b/app/workers/Harvester.scala
@@ -66,13 +66,13 @@ class Harvester {
           case EvElemStart(_,"identifier",_,_) => readingId = true
           case EvElemStart(_,"setSpec",_,_) => readingSpec = true
           case EvText(text) if readingId => objId = Some(text); readingId = false
-          case EvText(text) if readingSpec => checkItem(objId, Some(text)); readingSpec = false
+          case EvText(text) if readingSpec => processItem(objId, Some(text)); readingSpec = false
           case _ =>
         }
       }
     }
 
-    def checkItem(objId: Option[String], collectionKey: Option[String]) = {
+    def processItem(objId: Option[String], collectionKey: Option[String]) = {
       println("Got OID:" + objId.getOrElse("Unknown") + " in coll: " + collectionKey.getOrElse("Unknown"))
       // look up collection, and process if known & item not already created
       val collOpt = Collection.findByTag(collectionKey.get);

--- a/conf/routes
+++ b/conf/routes
@@ -98,6 +98,7 @@ GET     /item/:id                    controllers.ItemController.item(id: Int)
 GET     /item/package/:id            controllers.ItemController.itemPackage(id: Int)
 GET     /item/deposit/:id            controllers.ItemController.itemDeposit(id: Int)
 GET     /item/mets/:id               controllers.ItemController.itemMets(id: Int)
+GET     /items/missingtopics         controllers.ItemController.itemsWithNoTopics
 
 # Topic pages
 GET     /topics                      controllers.Application.topics

--- a/test/integration/WorkbenchPagesSpec.scala
+++ b/test/integration/WorkbenchPagesSpec.scala
@@ -63,6 +63,16 @@ class WorkbenchPagesSpec extends Specification {
       browser.$("#sidenav_models").click
       assertThat(browser.title()).isEqualTo("Create Model - TopicHub")
     }
+
+    "provides link to items with no topics" in new WithBrowser(app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+      val user = create_user("sysadmin, analyst")
+      browser.goTo("http://localhost:" + port + "/login")
+      browser.$("#openid").click
+      browser.goTo("http://localhost:" + port + "/workbench")
+      browser.pageSource must contain("""<a id="sidenav_notopic_items" href="/items/missingtopics""")
+      browser.$("#sidenav_notopic_items").click
+      assertThat(browser.title()).isEqualTo("Items missing Topics - TopicHub")
+    }
   }
 
   "Workbench for analysts" should {
@@ -84,6 +94,14 @@ class WorkbenchPagesSpec extends Specification {
       browser.goTo("http://localhost:" + port + "/model/create")
       assertThat(browser.title()).isEqualTo("Error - TopicHub")
       browser.pageSource must contain("You are not authorized")
+    }
+
+    "does not provide link to items with no topics" in new WithBrowser(app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+      val user = create_user("analyst")
+      browser.goTo("http://localhost:" + port + "/login")
+      browser.$("#openid").click
+      browser.goTo("http://localhost:" + port + "/workbench")
+      browser.pageSource must not contain("""<a id="sidenav_notopic_items" href="/items/missingtopics""")
     }
 
     "provides link to Schemes" in new WithBrowser(app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {


### PR DESCRIPTION
Items with no Topics is a sign of an error state in the Cataloger as it
should always assign either Any or None topics.

This should help us identify Items where the Cataloging failed and thus
determine what next steps to take.

Closes #69