### PR TITLE
Handle exceptions during initial harvest start

### DIFF
--- a/app/models/Harvest.scala
+++ b/app/models/Harvest.scala
@@ -47,6 +47,14 @@ case class Harvest(id: Int,             // DB key
       .on('updated -> newDate, 'id -> id).executeUpdate()
     }
   }
+
+  def rollback = {
+    val newDate = HubUtils.advanceDate(updated, -freq)
+    DB.withConnection { implicit c =>
+      SQL("update harvest set updated = {updated} where id = {id}")
+      .on('updated -> newDate, 'id -> id).executeUpdate()
+    }
+  }
 }
 
 object Harvest {

--- a/app/models/HubUtils.scala
+++ b/app/models/HubUtils.scala
@@ -33,7 +33,7 @@ object HubUtils {
 
   def advanceDate(curDate: Date, days: Int): Date = {
     // clumsily convert to Java8 date for easy calculation of daily advance,
-    // but convernt back to old Date for JDBC ease of use
+    // but convert back to old Date for JDBC ease of use
     val newDt = curDate.toInstant.atZone(ZoneId.systemDefault).toLocalDateTime.plusDays(days)
     Date.from(newDt.atZone(ZoneId.systemDefault).toInstant)
   }

--- a/app/models/User.scala
+++ b/app/models/User.scala
@@ -31,7 +31,10 @@ case class User(id: Int, name: String, email: String,
 
   def hasRole(role: String): Boolean = {
     DB.withConnection { implicit c =>
-      val count = SQL("select count(*) as c from hub_user where role LIKE {role}").on('role -> ("%"+role+"%")).apply.head
+      val count = SQL("""SELECT COUNT(*) as c FROM hub_user
+                         WHERE id = {id}
+                         AND role LIKE {role}""")
+                      .on('id -> id, 'role -> ("%"+role+"%")).apply.head
       count[Long]("c") > 0
     }
   }
@@ -56,6 +59,15 @@ object User {
   def findByName(name: String): Option[User] = {
     DB.withConnection { implicit c =>
       SQL("select * from hub_user where name = {name}").on('name -> name).as(user.singleOpt)
+    }
+  }
+
+  def allByRole(role: String): List[User] = {
+    DB.withConnection { implicit c =>
+      SQL("""
+          SELECT * FROM hub_user
+          WHERE role LIKE {role}
+          """).on('role -> ("%"+role+"%")).as(user *)
     }
   }
 

--- a/app/views/email/abort_harvest.scala.txt
+++ b/app/views/email/abort_harvest.scala.txt
@@ -1,0 +1,13 @@
+@*****************************************************************************
+ * Email template used to notify sysadmins of harvest start failures         *
+ * Copyright (c) 2015 MIT Libraries                                          *
+ *****************************************************************************@
+@(harvest: Harvest, exception: String)
+An error occurred starting the following harvest:
+
+Harvest: @harvest.name
+Publisher: @harvest.publisher.get.name
+Link to Harvest: http://scoap3.topichub.org/harvest/@harvest.id
+
+Exception text:
+@exception

--- a/test/unit/UserSpec.scala
+++ b/test/unit/UserSpec.scala
@@ -40,6 +40,17 @@ class UserSpec extends Specification {
       }
     }
 
+    "#allByRole" in {
+      running(FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        User.allByRole("role1").size must equalTo(0)
+        val user = User.make("bob", "bob@example.com", "role1, role2", "identity")
+        val user2 = User.make("bob2", "bob2@example.com", "role1", "identity")
+        User.allByRole("role1").size must equalTo(2)
+        User.allByRole("role2").size must equalTo(1)
+        User.allByRole("sysadmin").size must equalTo(0)
+      }
+    }
+
     "#findByIdentity" in {
       running(FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         User.findByIdentity("identity") must equalTo(None)
@@ -63,6 +74,19 @@ class UserSpec extends Specification {
 
         val p = Publisher.make(user.id, "pubtag", "pubname", "pubdesc", "pubcat", "pubstatus", Some(""), Some(""))
         user.hasPublisher(1) must equalTo(true)
+      }
+    }
+
+    "#hasRole" in {
+      running(FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val user = User.make("bob", "bob@example.com", "role1, role2", "identity")
+        user.hasRole("role1") must equalTo(true)
+        user.hasRole("role2") must equalTo(true)
+        user.hasRole("popcorn") must equalTo(false)
+
+        val user2 = User.make("bob2", "bob2@example.com", "role1", "identity")
+        user2.hasRole("role1") must equalTo(true)
+        user2.hasRole("role2") must equalTo(false)
       }
     }
   }


### PR DESCRIPTION
Any lack of response or non-200 response code will revert the harvest.

All users with the role `sysadmin` will receive an email with details.

Test Harvest services URLs to throw different conditions:
1) http://repo.scoap3.org/oai2d (200 case, only condition where harvest continues)
2) http://repo.mit.edu/oai2d timesout (rescue: java.net.ConnectException)
3) http://localhost:9000/oai2d (404: default case)
4) http://localhost:9900/oai2d (rescue: java.net.ConnectException)
5) http://asdffdsaasdf.com/oai2d (rescue: java.net.ConnectException)

- Also fixes a bug in `User#hasRole(role)` where all users were treated as
having a role as long as any user had the role.

- This work is part of #211. There is one condition left in that ticket before
we close it. Namely, checking for OAI errors during parse.