### PR TITLE
Improves plan visibility and control in dashboard

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -982,6 +982,12 @@ object Application extends Controller with Security {
     )
   )
 
+  val planSetForm = Form(
+    single(
+      "channel_id" -> number
+    )
+  )
+
   def plan(id: Int) = isAuthenticated { identity => implicit request =>
     Plan.findById(id).map( plan =>
       subscriberMember(identity, plan.subscriber.get, Ok(views.html.plan.show(plan)))
@@ -1029,6 +1035,24 @@ object Application extends Controller with Security {
           plan.removeScheme(scheme)
           Redirect(routes.Application.editSubscriber(plan.subscriber.get.id))
         }).getOrElse(NotFound(views.html.static.trouble("No such scheme: " + schemeId)))
+      } else {
+        Unauthorized(views.html.static.trouble("You are not authorized"))
+      }
+    }).getOrElse(NotFound(views.html.static.trouble("No such subscriber plan: " + id)))
+  }
+
+  def setPlanChannel(id: Int) = isAuthenticated { identity => implicit request =>
+    Plan.findById(id).map( plan => {
+      if (plan.subscriber.get.userList().contains(identity)) {
+        planSetForm.bindFromRequest.fold (
+          errors => BadRequest(views.html.subscriber.edit(plan.subscriber.get, errors)),
+          value => {
+            Channel.findById(value).map( chan => {
+              plan.setChannel(chan)
+              Redirect(routes.Application.editSubscriber(plan.subscriber.get.id))
+            }).getOrElse(NotFound(views.html.static.trouble("No such channel: " + value)))
+          }
+        )
       } else {
         Unauthorized(views.html.static.trouble("You are not authorized"))
       }

--- a/app/models/Plan.scala
+++ b/app/models/Plan.scala
@@ -68,6 +68,13 @@ case class Plan(id: Int,                // DB key
       .on('plan_id -> id).as(Scheme.scheme *)
     }
   }
+
+  def setChannel(chan: Channel) = {
+    DB.withConnection { implicit c =>
+      SQL("update plan set channel_id = {chan_id} where id = {plan_id}")
+      .on('chan_id -> chan.id, 'plan_id -> id).executeUpdate()
+    }
+  }
 }
 
 object Plan {

--- a/app/views/layout/main.scala.html
+++ b/app/views/layout/main.scala.html
@@ -50,7 +50,6 @@
                       }</span>
                   </a>
                 </li>
-                <li><a id="nav_plans" href="@routes.Application.editSubscriber(currentSubId)">Plans</a></li>
               }
 
               @if(Application.currentUserHasRole("analyst")) {

--- a/app/views/static/home.scala.html
+++ b/app/views/static/home.scala.html
@@ -11,7 +11,7 @@
 
         <div class="list-group">
           <h3>Schemes</h3>
-          
+
           @schemes.map { scheme =>
             <a href="@routes.Application.topicBrowse(scheme.id)" class="list-group-item">
             @scheme.description
@@ -29,7 +29,7 @@
           <p>SCOAP<sup>3</sup> (Sponsoring Consortium for Open Access Publishing in Particle Physics) is a <a href="http://cern.ch">CERN</a>-managed service to deliver High-Energy Physics articles as open access. Visit them <a href="http://repo.scoap3.org">here</a>.</p>
           <p>The hub analyzes each article in the SCOAP<sup>3</sup> repository to extract <em>topics</em>. A topic is an identifier or term belonging to a standard vocabulary or name-space, known as its <em>scheme</em>.
              Relative to this scheme, the topic identifies, describes, characterizes or classifies the article. Topics help organize articles into groups that are of interest to subscribers:
-             all articles in a particular journal, everything written by a certain author, etc. Explore the topics within a scheme by clicking on one of the scheme browse links at the left.</p>
+             all articles in a particular journal, everything written by a certain author, etc. Find the topics (or articles) you want by <a href="@routes.Search.index">searching</a>, or explore topics within a scheme by clicking on one of the scheme browse links at the left.</p>
         </div>
       </div>
     </div>

--- a/app/views/subscriber/dashboard.scala.html
+++ b/app/views/subscriber/dashboard.scala.html
@@ -6,7 +6,7 @@
 @import java.time.YearMonth
 @import java.time.LocalDateTime
 @currentSubId = @{ Application.currentSubscriberId }
-@layout.main("Subscriber Dashboard -  TopicHub") {
+@layout.main("Subscriber Dashboard - TopicHub") {
 <div class="container-fluid">
   <div class="row-fluid">
     <div class="col-md-12">
@@ -28,34 +28,6 @@
       </ul>
       <hr />
 
-      <h4>Subscriptions by Scheme</h4>
-      <ul class="list-group">
-      @for(s <- sub.plannedSchemes) {
-        <li class="list-group-item">
-          <span class="badge">@Subscription.schemeCount(sub.id, s.id)</span>
-          <a href=@routes.Application.subscriptionBrowse("scheme", s.id)>@s.description</a>
-        </li>
-      }
-      </ul>
-      <h6>Note: deliveries and rejections can be seen as you click through the links above.</h6>
-      <hr />
-
-      <h4>Destinations</h4>
-      <ul class="list-group">
-        @sub.channels.map { chan =>
-          <li class="list-group-item alert-info">
-            <span class="badge">@chan.transfers</span>
-            <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
-            <a href="@routes.Application.channel(chan.id)">@chan.description</a>
-          </li>
-        }
-        <li class="list-group-item alert-danger">
-          <span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>
-          <a href="@routes.Application.newChannel(sub.id)">Add a new destination</a>
-        </li>
-      </ul>
-      <hr />
-
       <h4>Last Harvest</h4>
       <ul class="list-group">
         @* todo: update logic to return all harvests for all publishers
@@ -73,11 +45,61 @@
           }
         </li>
       </ul>
+      <hr />
 
+      <h4>Destinations</h4>
+      <ul class="list-group" ondragstart="handleDragStart(event)">
+        @sub.channels.map { chan =>
+          <li class="list-group-item alert-info" id="channel-@chan.id" draggable="true">
+            <span class="badge">@chan.transfers</span>
+            <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+            <a href="@routes.Application.channel(chan.id)">@chan.description</a>
+          </li>
+        }
+        <li class="list-group-item alert-danger">
+          <span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>
+          <a href="@routes.Application.newChannel(sub.id)">Add a new destination</a>
+        </li>
+      </ul>
     </div>
 
     <div class="col-md-9">
       <div id="chart_div2"></div>
+    </div>
+    <div class="col-md-12">
+      <h4>Subscriptions by Plan</h4>
+      <div class="row">
+        <div class="col-md-3">
+          <ul class="list-group" id="noplan" ondragenter="return false" ondragover="return false" ondragstart="handleDragStart(event)" ondrop="handleDrop(event, this)">
+          <h5>Unassigned Schemes</h5>
+          <h5>[No destination]</h5>
+          @for(s <- sub.unplannedSchemes) {
+            <li class="list-group-item" id="scheme-@s.id" draggable="true">
+              <span class="badge">@Subscription.schemeCount(sub.id, s.id)</span>
+              <a href="@routes.Application.scheme(s.id)" draggable="false"><img src="@s.logo"/></a>
+              <a href="@routes.Application.subscriptionBrowse("scheme", s.id)" draggable="false">@s.description</a>
+            </li>
+          }
+          </ul>
+        </div>
+        @for(plan <- sub.plans) {
+          <div class="col-md-3">
+            <ul class="list-group" id="plan-@plan.id" ondragenter="return false" ondragover="return false" ondragstart="handleDragStart(event)" ondrop="handleDrop(event, this)">
+            <h5>@plan.name <span class="glyphicon glyphicon-@plan.icon" aria-hidden="true"></span></h5>
+            <h5 id="chanplan-@plan.id">@plan.channel.get.description</h5>
+            @for(s <- plan.schemes) {
+              <li class="list-group-item" id="scheme-@s.id" draggable="true">
+                <span class="badge">@Subscription.schemeCount(sub.id, s.id)</span>
+                <a href="@routes.Application.scheme(s.id)" draggable="false"><img src="@s.logo"/></a>
+                <a href="@routes.Application.subscriptionBrowse("scheme", s.id)" draggable="false">@s.description</a>
+              </li>
+            }
+            </ul>
+          </div>
+        }
+      </div>
+      <h6>Note: Drag a scheme from/to unassigned to a plan to enable/disable subscriptions in it. Drag a destination to a plan to direct its subscriptions there.</h6>
+      <hr />
     </div>
   </div>
 </div>
@@ -115,5 +137,85 @@
     // Instantiate and draw our chart, passing in some options.
     var chart2 = new google.visualization.ColumnChart(document.getElementById('chart_div2'));
     chart2.draw(data2, options2);
+  }
+
+  function handleDragStart(event) {
+    if (event.target instanceof HTMLLIElement) {
+      event.dataTransfer.setData('text/x-dbid', event.target.id);
+      var effect = startsWith(event.target.id, "scheme") ? 'move' : 'copy';
+      event.dataTransfer.effectAllowed = effect;
+    } else {
+      event.preventDefault();
+    }
+  }
+
+  function handleDrop(event, target) {
+    var srcId = event.dataTransfer.getData('text/x-dbid');
+    var source = document.getElementById(srcId);
+    if (startsWith(srcId, "scheme")) {
+      var schemeId = source.id.substring(7); // strip off the "scheme-" from id string
+      // ignore any drop operation onto the parent of the source (i.e. circular drop)
+      if (source.parentNode.id !== target.id) {
+        // there are 3 cases to consider
+        if (source.parentNode.id === "noplan") {
+          // user dropping an unassigned scheme onto a plan - just add to target plan
+          addToPlan(schemeId, source, target);
+        } else if (target.id === "noplan") {
+          // user moving a scheme from a plan to unassigned status - remove from plan
+          removeFromPlan(schemeId, source, target, true);
+        } else {
+          // user moving a scheme from one plan to another - remove then add
+          removeFromPlan(schemeId, source, target, false);
+          addToPlan(schemeId, source, target);
+        }
+      }
+    } else {
+      // update of plan channel
+      updatePlan(source, target);
+    }
+    if (event.stopPropagation) {
+      event.stopPropagation(); // stops the browser from redirecting
+    }
+    event.preventDefault();
+    return false;
+  }
+
+  function addToPlan(schemeId, source, target) {
+    var addUrl = "plan/" + target.id.substring(5); // strip off the "plan-" from id string
+    $.post(addUrl, { scheme_id: schemeId },
+           function(data) { updateDOM(source, target); }
+    );
+  }
+
+  function removeFromPlan(schemeId, source, target, update) {
+    var planId = source.parentNode.id.substring(5); // strip off the "plan-" from id string
+    var remUrl = "plan/" + planId + "/remove/" + schemeId;
+    $.get(remUrl, function(data) {
+        if (update) { updateDOM(source, target);  }
+      }
+    );
+  }
+
+  function updatePlan(source, target) {
+    var planId = target.id.substring(5); // strip off the "plan-" from id string
+    var updUrl = "plan/" + planId + "/channel";
+    var chanId = source.id.substring(8); // strip off "channel-" from id string
+    //alert("URL: " + updUrl + "CID: " + chanId);
+    $.post(updUrl, { channel_id: chanId },
+      function(data) {
+        var chanName = source.getElementsByTagName("a")[0].innerHTML;
+        document.getElementById("chanplan-" + planId).innerHTML = chanName;
+      }
+    );
+  }
+
+  function updateDOM(source, target) {
+    var copy = source.cloneNode(true);
+    source.parentNode.removeChild(source);
+    target.appendChild(copy);
+  }
+
+  function startsWith(token, prefix) {
+    return token.substring(0, prefix.length) === prefix;
   }
 </script>

--- a/app/views/subscription/browse.scala.html
+++ b/app/views/subscription/browse.scala.html
@@ -12,7 +12,7 @@
   </div>
   <ul>
     @subs.map { sub =>
-      <li><a href="@routes.Application.topic(sub.topic.id)">@sub.topic.tag</a> @sub.topic.name Transfers: @sub.transferCount</li>
+      <li><a href="@routes.Application.topic(sub.topic.id)">@sub.topic.tag</a> @HubUtils.toLabel(sub.topic.name) Transfers: @sub.transferCount</li>
     }
   </ul>
   @tags.pagination(page, 10, total, routes.Application.subscriptionBrowse(filter, value).toString, subs.length)

--- a/conf/routes
+++ b/conf/routes
@@ -145,6 +145,7 @@ POST    /plans/:sid                 controllers.Application.createPlan(sid: Int)
 DELETE  /plan/:id                   controllers.Application.deletePlan(id: Int)
 POST    /plan/:id                   controllers.Application.addPlanScheme(id: Int)
 GET     /plan/:id/remove/:sid       controllers.Application.removePlanScheme(id: Int, sid: Int)
+POST    /plan/:id/channel           controllers.Application.setPlanChannel(id: Int)
 
 # Subscription pages
 GET     /subscriptions/browse       controllers.Application.subscriptionBrowse(filter: String, value: Int, page: Int ?= 0)

--- a/test/integration/NavigationPagesSpec.scala
+++ b/test/integration/NavigationPagesSpec.scala
@@ -33,14 +33,6 @@ class NavigationPagesSpec extends Specification {
         browser.pageSource must not contain("""<a id="nav_sub_dashboard" href="/dashboard">""")
       }
 
-      "does not include plans" in new WithBrowser(
-        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
-        val sub_user = User.make("sub", "sub@example.com", "", "another_user")
-        Subscriber.make(sub_user.id, "Sub Name", "cat", "contact", Some("link"), Some("logo"))
-        browser.goTo("http://localhost:" + port)
-        browser.pageSource must not contain(s"""<a id="nav_plans" href="/subscriber/">""")
-      }
-
       "does not include workbench"  in new WithBrowser(
         app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         val sub_user = User.make("sub", "sub@example.com", "", "another_user")
@@ -85,16 +77,6 @@ class NavigationPagesSpec extends Specification {
         browser.goTo("http://localhost:" + port + "/login")
         browser.$("#openid").click
         browser.pageSource must not contain("""<a id="nav_sub_dashboard" href="/dashboard">""")
-      }
-
-      "does not include plans" in new WithBrowser(
-        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
-        create_user("")
-        val sub_user = User.make("sub", "sub@example.com", "", "another_user")
-        Subscriber.make(sub_user.id, "Sub Name", "cat", "contact", Some("link"), Some("logo"))
-        browser.goTo("http://localhost:" + port + "/login")
-        browser.$("#openid").click
-        browser.pageSource must not contain(s"""<a id="nav_plans" href="/subscriber/">""")
       }
 
       "does not include workbench" in new WithBrowser(
@@ -163,15 +145,6 @@ class NavigationPagesSpec extends Specification {
 
       "includes dashboard with counter if something to review" in {
         skipped(": I'm too lazy to write this now")
-      }
-
-      "includes plans" in new WithBrowser(
-        app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
-        val s = Subscriber.make(create_user("").id, "Sub Name", "cat", "contact",
-                          Some("link"), Some("logo"))
-        browser.goTo("http://localhost:" + port + "/login")
-        browser.$("#openid").click
-        browser.pageSource must contain(s"""<a id="nav_plans" href="/subscriber/${s.id}/edit">""")
       }
 
       "does not include workbench" in new WithBrowser(

--- a/test/unit/PlanSpec.scala
+++ b/test/unit/PlanSpec.scala
@@ -152,5 +152,20 @@ class PlanSpec extends Specification {
         p.schemes.size must equalTo(2)
       }
     }
+
+    "#setChannel" in {
+      running(FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        User.create("bob", "bob@example.com", "pwd", "role1")
+        val sub = Subscriber.make(1, "Sub Name", "cat", "contact", Some("link"), Some("logo"))
+        val chan = Channel.make(Subscriber.findById(1).get.id, "protocol", "mode", "description", "userid", "password", "http://example.com")
+        val chan2 = Channel.make(Subscriber.findById(1).get.id, "protocol", "mode", "description", "userid", "password", "http://example.com")
+
+        Plan.findById(1) must equalTo(None)
+        val p = Plan.make(sub.id, chan.id, "name", "description", "thumbs-up", "deliver", "review", "subscribe", "review")
+        p.channel.get.id must equalTo(chan.id)
+        p.setChannel(chan2)
+        Plan.findById(1).get.channel.get.id must equalTo(chan2.id)
+      }
+    }
   }
 }


### PR DESCRIPTION
A Drag-and-Drop interface added to dashboard, making it easy and intuitive to assign schemes (and thus all
the subscriptions based on their topics) to plans. DND also added for assigning channels to plans.
Closes #226