### PR TITLE
Adds disposable target for testing email function

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -796,9 +796,7 @@ object Application extends Controller with Security {
         val adminEmails = subscriber.adminList.map {user => user.email}.mkString(",")
         val subject = "SCOAP3Hub Request to Join Subscriber"
         val msg = views.txt.email.subscriber_join_request(subscriber, identity).body
-        if ( !play.api.Play.isTest(play.api.Play.current) ) {
-          Emailer.subscriberEmails(adminEmails, subject, msg)
-        }
+        Emailer.subscriberEmails(adminEmails, subject, msg)
         Ok(views.html.subscriber.request())
       }
     )
@@ -821,9 +819,7 @@ object Application extends Controller with Security {
       } else {
         sub.denyUser(userid)
       }
-      if ( !play.api.Play.isTest(play.api.Play.current) ) {
-        Emailer.subscriberEmails(user.email, subject, msg)
-      }
+      Emailer.subscriberEmails(user.email, subject, msg)
       Redirect(routes.Application.subscriberUsers(sub.id)).flashing(
         "success" -> s"User was ${res} membership to this Subscriber Group."
       )

--- a/app/services/email.scala
+++ b/app/services/email.scala
@@ -29,19 +29,19 @@ trait EmailService {
   val adminEmail = Play.configuration.getString("hub.admin.email").get
 
   def notify(to: String, subject: String, msg: String) {
-    val props = Map("to" -> to, "from" -> "noreply@scoap3hub.org",
+    val props = Map("to" -> munge(to), "from" -> "noreply@scoap3hub.org",
                     "subject" -> subject, "text" -> msg)
     send(props)
   }
 
   def feedback(from: String, msg: String, reply: Boolean) = {
-    val props = Map("to" -> adminEmail, "from" -> from,
+    val props = Map("to" -> munge(adminEmail), "from" -> from,
                     "subject" -> "SCOAP3Hub Feedback", "text" -> msg)
     send(if (reply) props + ("h:Reply-To" -> from) else props)
   }
 
   def subscriberEmails(to: String, subject: String, msg: String) = {
-    val props = Map("to" -> to, "from" -> "noreply@scoap3hub.org",
+    val props = Map("to" -> munge(to), "from" -> "noreply@scoap3hub.org",
                     "sender" -> "noreply@scoap3hub.org",
                     "subject" -> subject,
                     "text" -> msg)
@@ -49,6 +49,9 @@ trait EmailService {
   }
 
   def send(props: Map[String, String])
+
+  def munge(addrs: String) = if (play.api.Play.isTest(play.api.Play.current)) mailinate(addrs) else addrs
+  def mailinate(addrs: String) = addrs.split(",").toList.map(_.replace("@", "at") + "@mailinator.com").mkString(",")
 }
 
 object MailgunProvider extends EmailService {

--- a/app/workers/Harvester.scala
+++ b/app/workers/Harvester.scala
@@ -131,9 +131,7 @@ class Harvester {
       val sysadminEmails = User.allByRole("sysadmin").map(x => x.email).mkString(",")
       val msg = views.txt.email.abort_harvest(harvest, exception).body
       println(msg)
-      if ( !play.api.Play.isTest(play.api.Play.current) ) {
-        Emailer.notify(sysadminEmails, "SCOAP3Hub: An error occurred starting a Harvest", msg)
-      }
+      Emailer.notify(sysadminEmails, "SCOAP3Hub: An error occurred starting a Harvest", msg)
     }
 
     // OAI-PMH date filters are inclusive on both ends (from and until),


### PR DESCRIPTION
Uses mailinator.com for disposable email. Every real address foo@bar.com becomes fooatbar.com@mailinator.com
which can be examined via web UI (and API)
Closes #235