### PR TITLE
Method to kick off all harvests (protected by application key)

### DIFF
--- a/app/models/Harvest.scala
+++ b/app/models/Harvest.scala
@@ -67,6 +67,12 @@ object Harvest {
     }
   }
 
+  def all: List[Harvest] = {
+    DB.withConnection { implicit c =>
+      SQL("SELECT * FROM harvest").as(harv *)
+    }
+  }
+
   def findById(id: Int): Option[Harvest] = {
     DB.withConnection { implicit c =>
       SQL("select * from harvest where id = {id}").on('id -> id).as(harv.singleOpt)

--- a/app/views/harvest/create.scala.html
+++ b/app/views/harvest/create.scala.html
@@ -8,10 +8,9 @@
      <h2>Define a content harvest</h2>
     @form(routes.Application.createHarvest(pub.id)) {
         @inputText(harvestForm("name"))
-        @inputText(harvestForm("protocol"))
+        @inputText(harvestForm("protocol"), 'placeholder -> "oai-pmh is the only supported protocol at this time.")
         @inputText(harvestForm("service_url"))
         @inputText(harvestForm("resource_url"))
-        @inputText(harvestForm("freq"))
         @inputDate(harvestForm("start"))
         <input id="submit" type="submit" value="Create">
     }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -71,3 +71,7 @@ auth.client.external_auth_url="https://oidc.mit.edu/authorize?client_id=%s&redir
 auth.client.external_auth_url=${?AUTH_EXTERNAL_URL}
 auth.client.callback_url="http://localhost:9000/_oauth-callback"
 auth.client.callback_url=${?AUTH_CALLBACK_URL}
+
+# keys allowed to start non-authenticated harvests
+auth.harvest.key = ""
+auth.harvest.key = ${?HARVEST_KEY}

--- a/conf/routes
+++ b/conf/routes
@@ -36,6 +36,7 @@ GET     /harvest/:id                controllers.Application.harvest(id: Int)
 GET     /harvest/:id/start          controllers.Application.startHarvest(id: Int)
 GET     /harvest/:id/delete         controllers.Application.deleteHarvest(id: Int)
 GET     /knip/:cid/:hid/:oid        controllers.Application.pullKnownItem(cid: Int, hid: Int, oid: String, force: Boolean ?= false)
+GET     /harvests/startall/:key     controllers.Application.startAllHarvests(key: String)
 
 # Scheme pages
 GET     /schemes                    controllers.Application.schemes

--- a/test/integration/HarvestPagesSpec.scala
+++ b/test/integration/HarvestPagesSpec.scala
@@ -225,7 +225,6 @@ class HarvestPagesSpec extends Specification {
         browser.$("#protocol").text("protocol")
         browser.$("#service_url").text("http://www.example.com/oai2d")
         browser.$("#resource_url").text("http://www.example.com/record/${recordId}/")
-        browser.$("#freq").text("1")
         browser.$("#submit").click
         browser.pageSource must contain("Valid date required")
 

--- a/test/unit/HarvestSpec.scala
+++ b/test/unit/HarvestSpec.scala
@@ -14,6 +14,28 @@ class HarvestSpec extends Specification {
 
   "Harvest model" should {
 
+    "#all" in {
+      running(FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val u = User.make("bob", "bob@example.com", "pass", "roley")
+        val p = Publisher.make(u.id, "pubtag", "pubname", "pubdesc", "pubcat", "pubstatus", Some(""), Some(""))
+        Harvest.all must haveSize(0)
+
+        val h = Harvest.make(p.id, "name", "protocol", "http://www.example.com", "http://example.org", 1, new Date)
+        Harvest.all must haveSize(1)
+        Harvest.all must contain(h)
+
+        val h2 = Harvest.make(p.id, "name2", "protocol", "http://www.example.com", "http://example.org", 1, new Date)
+        Harvest.all must haveSize(2)
+        Harvest.all must contain(h)
+        Harvest.all must contain(h2)
+
+        Harvest.delete(h2.id)
+        Harvest.all must haveSize(1)
+        Harvest.all must contain(h)
+        Harvest.all must not contain(h2)
+      }
+    }
+
     "#findById" in {
       running(FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         User.create("bob", "bob@example.com", "pass", "roley")


### PR DESCRIPTION
The intent of this route and method are for a cron-like job to kick off
the process. As such, we need to handle this in a non-logged in state.
The application defined key should suffice for our level of protection
needs.

Other changes include: all Harvests default to frequency of 1 and that
cannot be changed in the UI. Admins can still kick off a harvest with a
greater frequency for catchup or testing purposes in the manual harvest
start form.

closes #206 