### PR TITLE
Reharvestable Items from Items missing Topics page

### DIFF
--- a/app/controllers/ItemController.scala
+++ b/app/controllers/ItemController.scala
@@ -29,6 +29,11 @@ object ItemController extends Controller with Security {
     }
   }
 
+  def delete(id: Int) = isAdmin { identity => implicit request =>
+    Item.delete(id)
+    Ok("Item deleted")
+  }
+
   private def itemBrowseTopic(id: Int, page: Int)(implicit request: Request[AnyContent]): Result = {
     Topic.findById(id).map( topic =>
       Ok(views.html.item.browse(id, topic.pagedItems(page, 10), "topic", topic.name, page, topic.itemCount))
@@ -42,7 +47,7 @@ object ItemController extends Controller with Security {
   }
 
   def itemsWithNoTopics = isAdmin { identity => { implicit request =>
-      Ok(views.html.item.notopics(Item.allMissingMetadata))
+      Ok(views.html.item.notopics(Item.allWithCatalogErrors))
     }
   }
 

--- a/app/models/Item.scala
+++ b/app/models/Item.scala
@@ -285,6 +285,24 @@ object Item {
     }
   }
 
+  def allWithCatalogErrors: List[Item] = {
+    DB.withConnection { implicit c =>
+      SQL("""
+            SELECT item.*
+            FROM item
+            WHERE id NOT IN (
+              SELECT DISTINCT item.id
+              FROM item
+              LEFT JOIN item_topic on item.id = item_topic.item_id
+              LEFT JOIN topic on topic.id = item_topic.topic_id
+              WHERE topic.tag = 'any'
+              OR topic.tag = 'none'
+              )
+            ORDER BY created DESC
+          """).as(item *)
+    }
+  }
+
   def findByKey(key: String): Option[Item] = {
     DB.withConnection { implicit c =>
       SQL("select * from item where obj_key = {key}").on('key -> key).as(item.singleOpt)

--- a/app/models/Publisher.scala
+++ b/app/models/Publisher.scala
@@ -48,6 +48,16 @@ case class Publisher(id: Int,  // DB key
     }
   }
 
+  def harvests = {
+    DB.withConnection { implicit c =>
+      SQL("""
+            SELECT *
+            FROM harvest
+            WHERE publisher_id = {id}
+          """).on('id -> id).as(Harvest.harv *)
+    }
+  }
+
   def harvestCount = {
     DB.withConnection { implicit c =>
       SQL("select count(*) from harvest where publisher_id = {id}").on('id -> id).as(scalar[Long].single)

--- a/app/views/item/notopics.scala.html
+++ b/app/views/item/notopics.scala.html
@@ -2,22 +2,35 @@
  * Page to display Items missing Topics (which is an error state)            *
  * Copyright (c) 2015 MIT Libraries                                          *
  *****************************************************************************@
- @(items: List[Item])(implicit request: play.api.mvc.RequestHeader)
+@(items: List[Item])(implicit request: play.api.mvc.RequestHeader)
 
 @layout.main("Items missing Topics -  TopicHub") {
   <div class="page-header">
     <h2>Items missing Topics</h2>
     <p>These items are in an error state as all Items should have at least
     one topic assigned by a successful cataloger worker.</p>
-    <p>At this time we have no method to clean up these records from this interface.
-    Once we know what likely steps we should take, we can add that.</p>
   </div>
   <ul class="list-group">
     @items.map { item =>
       <li class="list-group-item">
         @HubUtils.fmtPreciseDateTime(item.created)
-        <a href="@routes.ItemController.item(item.id)">View Local record</a>
-        <a href="@item.location.substring(7)">View Remote Record</a>
+        <div class="btn-group" role="group">
+          <a class="btn btn-default" href="@routes.ItemController.item(item.id)">View Local</a>
+
+          <a class="btn btn-default" href="@item.location.substring(7)">View Remote</a>
+
+          @if(Publisher.findById(Collection.findById(item.collectionId).get.publisherId).get.harvestCount == 1) {
+            <a id="reharvest-@item.id" class="btn btn-default" href="@routes.Application.pullKnownItem(
+            item.collectionId,
+            Publisher.findById(Collection.findById(item.collectionId).get.publisherId).get.harvests.head.id,
+            item.objKey,
+            true)">Attempt Reharvest</a>
+          } else {
+            <a class="btn btn-default disabled">Unable to determine Harvest</a>
+          }
+
+          <a id="delete-@item.id" class="btn btn-default" href="@routes.ItemController.delete(item.id)">Delete</a>
+        </div>
       </li>
    }
   </ul>

--- a/app/views/static/workbench.scala.html
+++ b/app/views/static/workbench.scala.html
@@ -17,7 +17,7 @@
             </a>
 
             <a id="sidenav_notopic_items" href="@routes.ItemController.itemsWithNoTopics" class="list-group-item">
-            Items with no Topics <span class="badge">@{ Item.allMissingMetadata.size }</span></a>
+            Items with no Topics <span class="badge">@{ Item.allWithCatalogErrors.size }</span></a>
           }
 
           <a id="sidenav_schemes" href="@routes.Application.schemes" class="list-group-item">Schemes</a>

--- a/conf/routes
+++ b/conf/routes
@@ -100,6 +100,7 @@ GET     /item/package/:id            controllers.ItemController.itemPackage(id: 
 GET     /item/deposit/:id            controllers.ItemController.itemDeposit(id: Int)
 GET     /item/mets/:id               controllers.ItemController.itemMets(id: Int)
 GET     /items/missingtopics         controllers.ItemController.itemsWithNoTopics
+GET     /item/delete/:id             controllers.ItemController.delete(id: Int)
 
 # Topic pages
 GET     /topics                      controllers.Application.topics

--- a/test/unit/PublisherSpec.scala
+++ b/test/unit/PublisherSpec.scala
@@ -189,6 +189,30 @@ class PublisherSpec extends Specification {
       }
     }
 
+    "#harvests"  in {
+      running(FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+        val u = User.make("bob", "bob@example.com", "pwd", "role1")
+        Publisher.all.size must equalTo(0)
+        val p = Publisher.make(u.id, "pubtag", "pubname", "pubdesc", "pubcat", "pubstatus", Some(""), Some(""))
+
+        p.harvests.size must equalTo(0)
+        val h1 = Harvest.make(p.id, "name", "protocol", "http://www.example.com", "http://example.org", 1, new Date)
+        p.harvests.size must equalTo(1)
+        p.harvests.contains(h1) must equalTo(true)
+        val h2 = Harvest.make(p.id, "name2", "protocol", "http://www.example.com", "http://example.org", 1, new Date)
+        p.harvests.contains(h1) must equalTo(true)
+        p.harvests.contains(h2) must equalTo(true)
+        p.harvests.size must equalTo(2)
+
+        val p2 = Publisher.make(u.id, "pubtag2", "pubname", "pubdesc", "pubcat", "pubstatus", Some(""), Some(""))
+        val h3 = Harvest.make(p2.id, "name3", "protocol", "http://www.example.com", "http://example.org", 1, new Date)
+        p.harvests.contains(h1) must equalTo(true)
+        p.harvests.contains(h2) must equalTo(true)
+        p.harvests.contains(h3) must equalTo(false)
+        p.harvests.size must equalTo(2)
+      }
+    }
+
     "#harvestCount" in {
       running(FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         val u = User.make("bob", "bob@example.com", "pwd", "role1")


### PR DESCRIPTION
- adds a method to explictily check for `Any/None` topics and uses that in determing problem Items
- adds a PullKnownItem link on the Items missing Topics page to allow sysadmins to attempt
a reharvest
 - note: this does not allow reharvesting from Publishers with multiple Harvests at this time
- allows sysadmins to delete an Item entirely from the Items missing Topics page if they determine
that is an appropriate course of action for the Item (i.e. they happen to know it is not
relevant to hub Subscribers or it was retracted upstream or something).

closes #255