### PR TITLE
Highlights valid drop targets on Subscriber Dashboard

### DIFF
--- a/app/views/subscriber/dashboard.scala.html
+++ b/app/views/subscriber/dashboard.scala.html
@@ -149,6 +149,8 @@
       event.dataTransfer.setData('text/x-dbid', event.target.id);
       var effect = startsWith(event.target.id, "scheme") ? 'move' : 'copy';
       event.dataTransfer.effectAllowed = effect;
+      $("#noplan").addClass("validtarget");
+      $("[id^=plan-]").addClass("validtarget");
     } else {
       event.preventDefault();
     }
@@ -157,6 +159,8 @@
   function handleDrop(event, target) {
     var srcId = event.dataTransfer.getData('text/x-dbid');
     var source = document.getElementById(srcId);
+    $("#noplan").removeClass("validtarget");
+    $("[id^=plan-]").removeClass("validtarget");
     if (startsWith(srcId, "scheme")) {
       var schemeId = source.id.substring(7); // strip off the "scheme-" from id string
       // ignore any drop operation onto the parent of the source (i.e. circular drop)

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -20,3 +20,8 @@ a.list-group-item:hover {
   font-weight: bold;
   text-decoration: underline;
 }
+
+.validtarget {
+  background-color: lightblue;
+  border: solid thin red;
+}


### PR DESCRIPTION
This could get fancier by not highlighting the Plan the Scheme is currently in as a valid drop target, but this is nice and simple and addresses the biggest UX concern.

closes #242
