### PR TITLE
Allow multiple OAuth providers to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,16 @@ This is a web application to allow users to discover, subscribe to,
 and obtain automatic delivery of, aggregations of article content from the SCOAP3 repository.
 
 [![Build Status](https://travis-ci.org/MITLibraries/scoap3hub.svg?branch=master)](https://travis-ci.org/MITLibraries/scoap3hub) [![Coverage Status](https://coveralls.io/repos/MITLibraries/scoap3hub/badge.svg?branch=master)](https://coveralls.io/r/MITLibraries/scoap3hub?branch=master)
+
+Authentication
+=====
+Authentication uses OAuth2 and has been confirmed working with both an MIT
+OAuth server and Google. Examples for each are currently in the authentication.conf file.
+Additional providers will likely work as well. You can override all authentication related
+settings via Environment Variables.
+
+Setting Environment Variables for `AUTH_ID` and `AUTH_SECRET` with values from your
+OAuth provider will be required. `AUTH_CALLBACK_URL` should be whatever domain you are
+running this app on plus `/_oauth-callback`. You will need to configure that on your
+OAuth provider site as well. For development `http://localhost:9000/_oauth-callback`
+(or similar) should also be set with the provider.

--- a/app/controllers/AuthenticationController.scala
+++ b/app/controllers/AuthenticationController.scala
@@ -17,14 +17,15 @@ object AuthenticationController extends Controller {
   def login = Action { implicit request =>
     val oauth2 = new OAuth2(Play.current)
     val callbackUrl = services.routes.OAuth2.callback(None, None).absoluteURL()
-    val scope = "openid email profile"   // this is used auth the ticket to provide info we need later
+    val scope = "openid%20email%20profile"   // this is used auth the ticket to provide info we need later
     val state = UUID.randomUUID().toString  // random confirmation string
     val redirectUrl = oauth2.getAuthorizationUrl(callbackUrl, scope, state)
+    val loginText = Play.configuration.getString("auth.login_text").get
     // todo: withSession used like this actually logs the user out
     // which sort of makes sense actually. However, what may make
     // sense would be to redirect the user if they are logged in
     // so we never hit this line that logs them out again.
-    Ok(views.html.login.index("", redirectUrl)).
+    Ok(views.html.login.index(loginText, redirectUrl)).
       withSession("oauth-state" -> state)
   }
 

--- a/app/services/OAuth2.scala
+++ b/app/services/OAuth2.scala
@@ -15,6 +15,12 @@ class OAuth2(application: Application) {
   lazy val auth_id = application.configuration.getString("auth.client.id").get
   lazy val auth_secret = application.configuration.getString("auth.client.secret").get
   lazy val auth_callback_url = application.configuration.getString("auth.client.callback_url").get
+  lazy val auth_name_field = application.configuration.getString("auth.response.name_field").get
+  lazy val auth_sub_field = application.configuration.getString("auth.response.sub_field").get
+  lazy val auth_email_field = application.configuration.getString("auth.response.email_field").get
+  lazy val auth_token_url = application.configuration.getString("auth.client.token_url").get
+  lazy val auth_profile_url = application.configuration.getString("auth.client.profile_url").get
+  lazy val auth_identity_provider = application.configuration.getString("auth.reponse.identity_provider").get
 
   def getAuthorizationUrl(redirectUri: String, scope: String, state: String): String = {
     val baseUrl = application.configuration.getString("auth.client.external_auth_url").get
@@ -22,15 +28,18 @@ class OAuth2(application: Application) {
   }
 
   def getToken(code: String): Future[String] = {
-    val tokenResponse = WS.url("https://oidc.mit.edu/token")(application).
-      withQueryString("client_id" -> auth_id,
-        "client_secret" -> auth_secret,
-        "code" -> code,
-        "grant_type" -> "authorization_code",
-        "redirect_uri" -> auth_callback_url).
+    val data = Map(
+      "client_id" -> Seq(auth_id),
+      "client_secret" -> Seq(auth_secret),
+      "code" -> Seq(code),
+      "grant_type" -> Seq("authorization_code"),
+      "redirect_uri" -> Seq(auth_callback_url)
+      )
+
+    val tokenResponse = WS.url(auth_token_url)(application).
       withAuth(auth_id, auth_secret, WSAuthScheme.BASIC).
       withHeaders(HeaderNames.ACCEPT -> MimeTypes.JSON).
-      post(Results.EmptyContent())
+      post(data)
 
     tokenResponse.flatMap { response =>
       (response.json \ "access_token").asOpt[String].fold(Future.failed[String](new IllegalStateException("Sod off!"))) { accessToken =>
@@ -46,7 +55,7 @@ object OAuth2 extends Controller {
   def redirectToExternalAuthServer(requestUri: String) = Action { implicit request =>
     if ( play.api.Play.isTest(play.api.Play.current) ) {
       val response = Json.parse("""
-          { "sub":"current_user", "name":"Firstname M Lastname", "preferred_username":"flastname",
+          { "id":"current_user", "sub":"current_user", "name":"Firstname M Lastname", "preferred_username":"flastname",
            "given_name":"Firstname", "family_name":"Lastname", "middle_name":"M",
            "email":"flastname@example.com", "email_verified":true }
          """)
@@ -78,7 +87,7 @@ object OAuth2 extends Controller {
   def success() = Action.async { request =>
     implicit val app = Play.current
     request.session.get("oauth-token").fold(Future.successful(Unauthorized("No way Jose"))) { authToken =>
-      WS.url("https://oidc.mit.edu/userinfo").
+      WS.url(oauth2.auth_profile_url).
         withHeaders(HeaderNames.AUTHORIZATION -> ("Bearer " + s"$authToken")).
         get().map { response =>
           lookupUser(response.json)
@@ -87,10 +96,10 @@ object OAuth2 extends Controller {
   }
 
   def lookupUser(response: play.api.libs.json.JsValue) = {
-    val identity_provider = "https://oidc.mit.edu/"
-    val email = (response \ "email").as[String]
-    val sub = (response \ "sub").as[String]
-    val name = (response \ "preferred_username").as[String]
+    val identity_provider = oauth2.auth_identity_provider
+    val email = (response \ oauth2.auth_email_field).as[String]
+    val sub = (response \ oauth2.auth_sub_field).as[String]
+    val name = (response \ oauth2.auth_name_field).as[String]
     val check_user = User.findByIdentity(identity_provider + sub)
     val user = if (check_user == None) {
       // create them

--- a/app/views/login/index.scala.html
+++ b/app/views/login/index.scala.html
@@ -1,7 +1,8 @@
-@(message: String, externalAuthUrl: String)(implicit request: play.api.mvc.RequestHeader)
+@(loginText: String, externalAuthUrl: String)(implicit request: play.api.mvc.RequestHeader)
 
 @layout.main("Login to SCOAP3 - TopicHub") {
   <h2>Not Yet Authenticated</h2>
-  <h3>@message</h3>
-  <a id="openid" href="/_external-oauth?requestUri=@helper.urlEncode(externalAuthUrl)"><em><b>Log in with your MIT ID!</b></em></a>
+  <a id="openid" class="btn btn-primary" href="/_external-oauth?requestUri=@helper.urlEncode(externalAuthUrl)">
+    @loginText
+  </a>
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -63,14 +63,8 @@ hub.email.url="https://api.mailgun.net/v2/topichub.mailgun.org/messages"
 hub.email.apikey="fake"
 hub.email.apikey=${?MAILGUN_API_KEY}
 
-auth.client.id="fake_auth_id"
-auth.client.secret="fake_auth_secret"
-auth.client.id=${?AUTH_ID}
-auth.client.secret=${?AUTH_SECRET}
-auth.client.external_auth_url="https://oidc.mit.edu/authorize?client_id=%s&redirect_uri=%s&scope=%s&state=%s&response_type=code"
-auth.client.external_auth_url=${?AUTH_EXTERNAL_URL}
-auth.client.callback_url="http://localhost:9000/_oauth-callback"
-auth.client.callback_url=${?AUTH_CALLBACK_URL}
+# Authentication is Configured in authentication.conf
+include "authentication"
 
 # keys allowed to start non-authenticated harvests
 auth.harvest.key = ""

--- a/conf/authentication.conf
+++ b/conf/authentication.conf
@@ -1,0 +1,38 @@
+# Auth Client ID and Secret are supplied by OAuth provider
+auth.client.id="fake_auth_id"
+auth.client.secret="fake_auth_secret"
+auth.client.id=${?AUTH_ID}
+auth.client.secret=${?AUTH_SECRET}
+
+# Google Oauth Config Example Config
+#auth.client.token_url="https://accounts.google.com/o/oauth2/token"
+#auth.client.profile_url="https://www.googleapis.com/oauth2/v2/userinfo"
+#auth.response.name_field="email"
+#auth.response.sub_field="id"
+#auth.response.email_field="email"
+#auth.reponse.identity_provider="https://accounts.google.com/"
+#auth.login_text="Login with Google"
+
+# MIT OAuth Example Config
+auth.client.token_url="https://oidc.mit.edu/token"
+auth.client.profile_url="https://oidc.mit.edu/userinfo"
+auth.response.name_field="name"
+auth.response.sub_field="sub"
+auth.response.email_field="email"
+auth.reponse.identity_provider="https://oidc.mit.edu/"
+auth.client.external_auth_url="https://oidc.mit.edu/authorize?client_id=%s&redirect_uri=%s&scope=%s&state=%s&response_type=code"
+auth.login_text="Login with your MIT ID"
+
+# Callback URL needs to be configured in the OAuth Provider as well
+auth.client.callback_url="http://localhost:9000/_oauth-callback"
+auth.client.callback_url=${?AUTH_CALLBACK_URL}
+
+# All auth values can be overridden via ENV as follows:
+auth.client.token_url=${?AUTH_CLIENT_TOKEN_URL}
+auth.client.profile_url=${?AUTH_CLIENT_PROFILE_URL}
+auth.response.name_field=${?AUTH_RESPONSE_NAME_FIELD}
+auth.response.sub_field=${?AUTH_RESPONSE_SUB_FIELD}
+auth.response.email_field=${?AUTH_RESPONSE_EMAIL_FIELD}
+auth.reponse.identity_provider=${?AUTH_RESPONSE_IDENTITY_PROVIDER}
+auth.client.external_auth_url=${?AUTH_CLIENT_EXTERNAL_AUTH_URL}
+auth.login_text=${?AUTH_LOGIN_TEXT}

--- a/test/ApplicationSpec.scala
+++ b/test/ApplicationSpec.scala
@@ -1,7 +1,7 @@
 import org.specs2.mutable._
 import org.specs2.runner._
 import org.junit.runner._
-
+import play.api.Play
 import play.api.test._
 import play.api.test.Helpers._
 import play.api.libs.json._
@@ -36,7 +36,7 @@ class ApplicationSpec extends Specification {
       val action = route(FakeRequest(GET, "/login")).get
       status(action) must equalTo(OK)
       contentType(action) must beSome.which(_ == "text/html")
-      contentAsString(action) must contain ("Log in with your MIT ID")
+      contentAsString(action) must contain (Play.configuration.getString("auth.login_text").get)
     }
 
     "display login screen when a non-logged in user asks for an analyst page" in new WithApplication(FakeApplication(additionalConfiguration = inMemoryDatabase())) {
@@ -56,7 +56,7 @@ class ApplicationSpec extends Specification {
       println("user created ---" + user + "------")
       val action = route(FakeRequest(GET, "/workbench").withSession(("connected", user.identity))).get
       redirectLocation(action) must beNone
-      contentAsString(action) must not contain ("Log in with your MIT ID")
+      contentAsString(action) must not contain (Play.configuration.getString("auth.login_text").get)
     }
   }
 }

--- a/test/integration/AuthenticationPagesSpec.scala
+++ b/test/integration/AuthenticationPagesSpec.scala
@@ -4,6 +4,7 @@ import org.junit.runner._
 import org.specs2.mock._
 import java.util.Date
 
+import play.api.Play
 import play.api.test._
 import play.api.test.Helpers._
 import org.fest.assertions.Assertions.assertThat
@@ -22,14 +23,14 @@ class AuthenticationPageSpec extends Specification with Mockito {
   "Application" should {
     "display a login screen" in new WithBrowser(app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
       browser.goTo("http://localhost:" + port + "/login")
-      browser.pageSource must contain("Log in with your MIT ID")
+      browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
       assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
     }
 
     "Analyst protected pages" should {
       "prompt for login when not signed in" in new WithBrowser(app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         browser.goTo("http://localhost:" + port + "/workbench")
-        browser.pageSource must contain("Log in with your MIT ID")
+        browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
         assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
       }
 
@@ -64,7 +65,7 @@ class AuthenticationPageSpec extends Specification with Mockito {
     "Login protected pages" should {
       "prompt for login when not signed in" in new WithBrowser(app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         browser.goTo("http://localhost:" + port + "/dashboard")
-        browser.pageSource must contain("Log in with your MIT ID")
+        browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
         assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
       }
 

--- a/test/integration/CullPagesSpec.scala
+++ b/test/integration/CullPagesSpec.scala
@@ -6,7 +6,6 @@ import play.api.test.Helpers._
 import org.fest.assertions.Assertions.assertThat
 import play.api.Application
 import play.api.Play
-import play.api.Play.current
 import models.{ Collection, ContentType, Cull, Publisher, ResourceMap, User, Subscriber }
 
 /**
@@ -28,7 +27,7 @@ class CullPagesSpec extends Specification {
         val pub = Publisher.make(pub_user.id, "pubtag", "pubname", "pubdesc", "pubcat",
                                  "pubstatus", Some("http://www.example.com"), Some(""))
         browser.goTo("http://localhost:" + port + "/publisher/" + pub.id + "/createC")
-        browser.pageSource must contain("Log in with your MIT ID")
+        browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
         assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
       }
 
@@ -51,7 +50,7 @@ class CullPagesSpec extends Specification {
                                  "pubstatus", Some("http://www.example.com"), Some(""))
         val cull = Cull.make(pub.id, "name", "soft", None, 1, new Date)
         browser.goTo("http://localhost:" + port + "/cull/" + cull.id)
-        browser.pageSource must contain("Log in with your MIT ID")
+        browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
         assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
       }
 
@@ -64,7 +63,7 @@ class CullPagesSpec extends Specification {
         val cull = Cull.make(pub.id, "name", "soft", None, 1, new Date)
         browser.goTo("http://localhost:" + port + "/cull/" + cull.id + "/start?span=1")
         Cull.findById(cull.id).get.updated must equalTo(cull.updated)
-        browser.pageSource must contain("Log in with your MIT ID")
+        browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
         assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
       }
 
@@ -77,7 +76,7 @@ class CullPagesSpec extends Specification {
         val cull = Cull.make(pub.id, "name", "soft", None, 1, new Date)
         browser.goTo("http://localhost:" + port + "/cull/" + cull.id + "/delete")
         Cull.findById(cull.id).get must equalTo(cull)
-        browser.pageSource must contain("Log in with your MIT ID")
+        browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
         assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
       }
 
@@ -93,7 +92,7 @@ class CullPagesSpec extends Specification {
         var collection = Collection.make(pub.id, ct.id, rm.id, "coll", "desc", "open")
         browser.goTo("http://localhost:" + port + "/knix/" + collection.id +
                      "/scoap:asdf:fdsa")
-        browser.pageSource must contain("Log in with your MIT ID")
+        browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
         assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
       }
     }

--- a/test/integration/DashboardPagesSpec.scala
+++ b/test/integration/DashboardPagesSpec.scala
@@ -3,6 +3,7 @@ import org.specs2.runner._
 import org.junit.runner._
 import java.util.Date
 
+import play.api.Play
 import play.api.test._
 import play.api.test.Helpers._
 import org.fest.assertions.Assertions.assertThat
@@ -20,7 +21,7 @@ class DashboardPagesSpec extends Specification {
   "The Subscriber Dashboard" should {
     "prompts for login when not signed in" in new WithBrowser(app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
       browser.goTo("http://localhost:" + port + "/dashboard")
-      browser.pageSource must contain("Log in with your MIT ID")
+      browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
       assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
     }
 

--- a/test/integration/HarvestPagesSpec.scala
+++ b/test/integration/HarvestPagesSpec.scala
@@ -6,7 +6,6 @@ import play.api.test.Helpers._
 import org.fest.assertions.Assertions.assertThat
 import play.api.Application
 import play.api.Play
-import play.api.Play.current
 import models.{ Collection, ContentType, Harvest, Publisher, ResourceMap, User, Subscriber }
 
 /**
@@ -28,7 +27,7 @@ class HarvestPagesSpec extends Specification {
         val pub = Publisher.make(pub_user.id, "pubtag", "pubname", "pubdesc", "pubcat",
                                  "pubstatus", Some("http://www.example.com"), Some(""))
         browser.goTo("http://localhost:" + port + "/publisher/" + pub.id + "/createH")
-        browser.pageSource must contain("Log in with your MIT ID")
+        browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
         assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
       }
 
@@ -52,7 +51,7 @@ class HarvestPagesSpec extends Specification {
         val harvest = Harvest.make(pub.id, "name", "protocol", "http://www.example.com",
                                    "http://example.org", 1, new Date)
         browser.goTo("http://localhost:" + port + "/harvest/" + harvest.id)
-        browser.pageSource must contain("Log in with your MIT ID")
+        browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
         assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
       }
 
@@ -66,7 +65,7 @@ class HarvestPagesSpec extends Specification {
                                    "http://example.org", 1, new Date)
         browser.goTo("http://localhost:" + port + "/harvest/" + harvest.id + "/start?span=1")
         Harvest.findById(harvest.id).get.updated must equalTo(harvest.updated)
-        browser.pageSource must contain("Log in with your MIT ID")
+        browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
         assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
       }
 
@@ -80,7 +79,7 @@ class HarvestPagesSpec extends Specification {
                                    "http://example.org", 1, new Date)
         browser.goTo("http://localhost:" + port + "/harvest/" + harvest.id + "/delete")
         Harvest.findById(harvest.id).get must equalTo(harvest)
-        browser.pageSource must contain("Log in with your MIT ID")
+        browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
         assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
       }
 
@@ -97,7 +96,7 @@ class HarvestPagesSpec extends Specification {
         var collection = Collection.make(pub.id, ct.id, rm.id, "coll", "desc", "open")
         browser.goTo("http://localhost:" + port + "/knip/" + collection.id + "/" + harvest.id +
                      "/scoap:asdf:fdsa")
-        browser.pageSource must contain("Log in with your MIT ID")
+        browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
         assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
       }
     }

--- a/test/integration/PublisherPagesSpec.scala
+++ b/test/integration/PublisherPagesSpec.scala
@@ -6,7 +6,6 @@ import play.api.test.Helpers._
 import org.fest.assertions.Assertions.assertThat
 import play.api.Application
 import play.api.Play
-import play.api.Play.current
 import models.{ Publisher, User, Subscriber }
 
 /**
@@ -91,7 +90,7 @@ class PublisherPagesSpec extends Specification {
           val pub = Publisher.make(pub_user.id, "pubtag", "pubname", "pubdesc", "pubcat", "pubstatus", Some("http://www.example.com"), Some(""))
           browser.goTo("http://localhost:" + port + "/publisher/" + pub.id)
           assertThat(browser.title()).isEqualTo("Publisher - TopicHub")
-          browser.pageSource must not contain("Log in with your MIT ID")
+          browser.pageSource must not contain("""<a id="openid" """)
           browser.pageSource must not contain("/publisher/1/edit")
         }
 
@@ -113,7 +112,7 @@ class PublisherPagesSpec extends Specification {
       "redirect to login if not signed in" in new WithBrowser(app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         browser.goTo("http://localhost:" + port + "/publishers")
         browser.$("a[href*='/publishers/create']").click()
-        browser.pageSource must contain("Log in with your MIT ID")
+        browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
         assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
       }
 
@@ -144,7 +143,7 @@ class PublisherPagesSpec extends Specification {
         val pub_user = User.make("pub", "pub@example.com", "some roles", "another_identity")
         val pub = Publisher.make(pub_user.id, "pubtag", "pubname", "pubdesc", "pubcat", "pubstatus", Some("http://www.example.com"), Some(""))
         browser.goTo("http://localhost:" + port + "/publisher/1/edit")
-        browser.pageSource must contain("Log in with your MIT ID")
+        browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
         assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
       }
 

--- a/test/integration/SubscriberUserPagesSpec.scala
+++ b/test/integration/SubscriberUserPagesSpec.scala
@@ -4,6 +4,7 @@ import org.junit.runner._
 import org.specs2.mock._
 import java.util.Date
 
+import play.api.Play
 import play.api.test._
 import play.api.test.Helpers._
 import org.fest.assertions.Assertions.assertThat
@@ -24,7 +25,7 @@ class SubscriberUserPagesSpec extends Specification {
         app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
       browser.goTo("http://localhost:" + port + "/subscribers/create")
       assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
-      browser.pageSource must contain("Log in with your MIT ID")
+      browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
     }
 
     "displays a link to join when there are Subscribers" in new WithBrowser(
@@ -53,7 +54,7 @@ class SubscriberUserPagesSpec extends Specification {
         app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
       browser.goTo("http://localhost:" + port + "/subscribers/join")
       assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
-      browser.pageSource must contain("Log in with your MIT ID")
+      browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
     }
 
     "allows User to request to join Subscriber when unjoined Subscribers exist" in new WithBrowser(
@@ -103,7 +104,7 @@ class SubscriberUserPagesSpec extends Specification {
 
       browser.goTo("http://localhost:" + port + "/subscriber/1/users")
       assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
-      browser.pageSource must contain("Log in with your MIT ID")
+      browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
     }
 
     "deny access for users not in the Subscriber group" in new WithBrowser(

--- a/test/integration/UserDashboardPagesSpec.scala
+++ b/test/integration/UserDashboardPagesSpec.scala
@@ -3,6 +3,7 @@ import org.specs2.runner._
 import org.junit.runner._
 import java.util.Date
 
+import play.api.Play
 import play.api.test._
 import play.api.test.Helpers._
 import org.fest.assertions.Assertions.assertThat
@@ -19,7 +20,7 @@ class UserDashboardPagesSpec extends Specification {
     "prompts for login when not signed in" in new WithBrowser(
         app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
       browser.goTo("http://localhost:" + port + "/myaccount")
-      browser.pageSource must contain("Log in with your MIT ID")
+      browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
       assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
     }
 


### PR DESCRIPTION
This provides support for Google and MIT OAuth, and thus likely others.

closes #292