### PR TITLE
Allow Subscriber#holds and #holdCount to exclude an Item

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -1239,10 +1239,10 @@ object Application extends Controller with Security {
     }
   }
 
-  def holdBrowse(id: Int, page: Int) = isAuthenticated { identity => implicit request =>
+  def holdBrowse(id: Int, page: Int, exclude: Int) = isAuthenticated { identity => implicit request =>
     Subscriber.findById(id).map( sub =>
       subscriberMember(identity, sub,
-                    Ok(views.html.hold.browse(sub.id, sub.holds(page), page, sub.holdCount)))
+                    Ok(views.html.hold.browse(sub.id, sub.holds(page, exclude), page, sub.holdCount(exclude))))
     ).getOrElse(NotFound(views.html.static.trouble("No such subscriber: " + id)))
   }
 
@@ -1256,7 +1256,7 @@ object Application extends Controller with Security {
       val sub = Subscriber.findById(hold.subscriberId).get
       if (sub.userList().contains(identity)) {
         conveyor ! (hold, accept)
-        Redirect(routes.Application.holdBrowse(sub.id, 0))
+        Redirect(routes.Application.holdBrowse(sub.id, 0, hold.itemId))
           .flashing(message_type -> message)
       } else {
         Unauthorized(views.html.static.trouble("You are not authorized"))

--- a/app/views/layout/main.scala.html
+++ b/app/views/layout/main.scala.html
@@ -45,7 +45,7 @@
                   <a id="nav_sub_dashboard" href="@routes.Application.subscriberDashboard">
                     Dashboard
                       <span class="badge">@{
-                      val count = Subscriber.findById(currentSubId).get.holdCount
+                      val count = Subscriber.findById(currentSubId).get.holdCount()
                       if (count > 0) count else ""
                       }</span>
                   </a>

--- a/app/views/subscriber/dashboard.scala.html
+++ b/app/views/subscriber/dashboard.scala.html
@@ -18,7 +18,7 @@
       <h4>Review</h4>
       <ul class="list-group">
         <li class="list-group-item">
-          <span class="badge">@Subscriber.findById(currentSubId).get.holdCount</span>
+          <span class="badge">@Subscriber.findById(currentSubId).get.holdCount()</span>
           <a href="@routes.Application.holdBrowse(currentSubId)">Items to review:</a>
         </li>
         <li class="list-group-item">

--- a/conf/routes
+++ b/conf/routes
@@ -162,7 +162,7 @@ POST    /plan/:id/channel           controllers.Application.setPlanChannel(id: I
 GET     /subscriptions/browse       controllers.Application.subscriptionBrowse(filter: String, value: Int, page: Int ?= 0)
 
 # Review (holds) pages
-GET     /holds/browse               controllers.Application.holdBrowse(id: Int, page: Int ?= 0)
+GET     /holds/browse               controllers.Application.holdBrowse(id: Int, page: Int ?= 0, exclude: Int ?= 0)
 GET     /hold/:id/resolve           controllers.Application.resolveHold(id: Int, accept: Boolean)
 
 # Topic Pick pages


### PR DESCRIPTION
This is admittedly a bit hacky, but it should be adequate for our needs.

I felt keeping state in the DB for this, but not for things like Item
status (cataloging state essentially) seemed a bit odd.

closes #113