### PR TITLE
Use Loggers

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -282,7 +282,7 @@ object Application extends Controller with Security {
           harvester ! h
           h.complete
         } else {
-          println("A harvest tried to start that had an invalid date.")
+          Logger.info("A harvest tried to start that had an invalid date.")
         }
       }
       Ok("kicked off all harvests")
@@ -1386,10 +1386,10 @@ object Application extends Controller with Security {
     val authorized_key = Play.configuration.getString("auth.harvest.key").get
     if (key == authorized_key) {
       indexer ! dtype
-      println("DEBUG: Reindex Job for " + dtype + " started")
+      Logger.info("Reindex Job for " + dtype + " started")
       Ok("Reindexing " + dtype + "s: started")
     } else {
-      println("DEBUG: A reindex tried to start without a valid key.")
+      Logger.warn("A reindex tried to start without a valid key.")
       Unauthorized("Reindexing " + dtype + "s: not allowed")
     }
   }

--- a/app/controllers/Search.scala
+++ b/app/controllers/Search.scala
@@ -22,13 +22,13 @@ object Search extends Controller {
     val offset = (page) * perpage
     val elastic_url = indexSvc +  target + "/_search?q=" + encQuery + "&from=" + offset + "&size=" + perpage
     val req = if (indexSvc.contains("bonsai.io")) {
-      println("DEBUG: use basic auth for WS elasticsearch call")
+      Logger.debug("use basic auth for WS elasticsearch call")
       WS.url(elastic_url)
         .withAuth(extractCredentials("username", indexSvc),
                   extractCredentials("password", indexSvc),
                   WSAuthScheme.BASIC)
     } else {
-      println("DEBUG: no auth for WS elasticsearch call")
+      Logger.debug("no auth for WS elasticsearch call")
       WS.url(elastic_url)
     }
 

--- a/app/models/Validator.scala
+++ b/app/models/Validator.scala
@@ -41,7 +41,7 @@ case class Validator(id: Int, scheme_id: Int, description: String, userId: Strin
     // compose the service call
     val svcCall = interpolate(serviceUrl.replaceAll("\\{topic\\}", topicId), true)
     val req = WS.url(svcCall)
-    //println("svcCall: " + svcCall)
+    Logger.debug("svcCall: " + svcCall)
     // need to define general abstraction - now just key off scheme tag
     if ("issn".equals(scheme.tag)) {
       req.get.map { resp => issnParse(resp.json) }

--- a/app/services/jsonModel.scala
+++ b/app/services/jsonModel.scala
@@ -145,16 +145,16 @@ object contentModelJson {
   def buildContentModel(model: JsValue) = {
     val formats = (model \ "cformats").get
     procJsArray(formats, 0, cformatFromContentModel)
-    println("finished formats")
+    Logger.info("finished formats")
     val schemes = (model \ "schemes").get
     procJsArray(schemes, 0, schemeFromContentModel)
-    println("finished schemes")
+    Logger.info("finished schemes")
     val ctypes = (model \ "ctypes").get
     procJsArray(ctypes, 0, ctypeFromContentModel)
-    println("finished ctypes")
+    Logger.info("finished ctypes")
     val resmaps = (model \ "resmaps").get
     procJsArray(resmaps, 0, resmapFromContentModel)
-    println("finished resmaps")
+    Logger.info("finished resmaps")
   }
 
   def cformatFromContentModel(jss: JsValue) {
@@ -168,7 +168,7 @@ object contentModelJson {
   }
 
   def schemeFromContentModel(jss: JsValue) {
-    //println(Json.stringify(jss))
+    Logger.debug(Json.stringify(jss))
     val tag = forName(jss, "tag")
     // only create if not already defined
     if (Scheme.findByTag(tag).isEmpty) {
@@ -302,7 +302,7 @@ object publisherModelJson {
   def buildPublisherModel(model: JsValue) = {
     val pubs = (model \ "publishers").get
     procJsArray(pubs, 0, pubFromPublisherModel)
-    println("finished publishers")
+    Logger.info("finished publishers")
   }
 
   def pubFromPublisherModel(jss: JsValue) {
@@ -322,7 +322,7 @@ object publisherModelJson {
   }
 
   def collFromPublisherModel(pid: Int)(jss: JsValue) {
-    //println(Json.stringify(jss))
+    Logger.debug(Json.stringify(jss))
     val tag = forName(jss, "tag")
     // only create if not already defined && dependencies found
     if (Collection.findByTag(tag).isEmpty) {
@@ -426,7 +426,7 @@ object subscriberModelJson {
   def buildSubscriberModel(model: JsValue) = {
     val subs = (model \ "subscribers").get
     procJsArray(subs, 0, subFromSubscriberModel)
-    println("finished subscribers")
+    Logger.info("finished subscribers")
   }
 
   def subFromSubscriberModel(jss: JsValue) {

--- a/app/workers/Indexer.scala
+++ b/app/workers/Indexer.scala
@@ -27,7 +27,7 @@ class IndexWorker extends Actor {
     case topic: Topic => Indexer.index(topic)
     //case subscriber: Subscriber => Indexer.index(subscriber)
     case dtype: String => Indexer.reindex(dtype)
-    case _ => println("I'm lost")
+    case _ => Logger.error("Unhandled Case in IndexWorker#receive")
   }
 }
 
@@ -40,13 +40,13 @@ object Indexer {
   def reindex(dtype: String) = {
     // delete current index type
     if (indexSvc.contains("bonsai.io")) {
-      // println("DEBUG: use basic auth for WS elasticsearch call")
+      Logger.debug("Use basic auth for WS elasticsearch call")
       WS.url(indexSvc + dtype)
         .withAuth(extractCredentials("username", indexSvc),
                   extractCredentials("password", indexSvc),
                   WSAuthScheme.BASIC).delete()
     } else {
-      // println("DEBUG: no auth for WS elasticsearch call")
+      Logger.debug("No auth for WS elasticsearch call")
       WS.url(indexSvc + dtype).delete()
     }
 
@@ -82,8 +82,8 @@ object Indexer {
     dataMap += "topicSchemeTag" -> toJson(item.topics.map(_.scheme.tag))
     dataMap += "topicTag" -> toJson(item.topics.map(_.tag))
     indexDocument(elastic_url, stringify(toJson(dataMap)))
-    // println("Item index: " + dataMap)
-    // println(indexSvc + "item/" + item.id)
+    Logger.debug("Item index: " + dataMap)
+    Logger.debug(indexSvc + "item/" + item.id)
   }
 
   def deindex(item: Item) = {
@@ -92,26 +92,26 @@ object Indexer {
 
   private def indexDocument(url: String, jdata: String) = {
     if (indexSvc.contains("bonsai.io")) {
-      // println("DEBUG: use basic auth for WS elasticsearch call")
+      Logger.debug("Use basic auth for WS elasticsearch call")
       WS.url(url)
         .withAuth(extractCredentials("username", indexSvc),
                   extractCredentials("password", indexSvc),
                   WSAuthScheme.BASIC).put(jdata)
     } else {
-      // println("DEBUG: no auth for WS elasticsearch call")
+      Logger.debug("No auth for WS elasticsearch call")
       WS.url(url).put(jdata)
     }
   }
 
   private def deleteDocument(url: String) = {
     if (indexSvc.contains("bonsai.io")) {
-      // println("DEBUG: use basic auth for WS elasticsearch call")
+      Logger.debug("Use basic auth for WS elasticsearch call")
       WS.url(url)
         .withAuth(extractCredentials("username", indexSvc),
                   extractCredentials("password", indexSvc),
                   WSAuthScheme.BASIC).delete
     } else {
-      // println("DEBUG: no auth for WS elasticsearch call")
+      Logger.debug("No auth for WS elasticsearch call")
       WS.url(url).delete
     }
   }
@@ -130,7 +130,7 @@ object Indexer {
                    "name" -> toJson(subscriber.name))
     val jdata = stringify(toJson(data))
     // debug
-    println("Subscriber index: " + jdata)
+    Logger.info("Subscriber index: " + jdata)
     val req = WS.url(indexSvc + "subscriber/" + subscriber.id)
     req.put(jdata)
   }

--- a/app/workers/Packager.scala
+++ b/app/workers/Packager.scala
@@ -12,7 +12,7 @@ import java.net.URL
 import java.util.zip.{ZipEntry, ZipOutputStream}
 
 import akka.actor.Actor
-
+import play.api._
 import play.api.Play.current
 import play.api.libs.ws._
 
@@ -32,7 +32,7 @@ import models.{Item, PackageMap}
 class PackageWorker extends Actor {
   def receive = {
     case item: Item => Packager.packageItem(item)
-    case _ => println("Unknown package command")
+    case _ => Logger.error("Unhandled Case in PackageWorker#receive")
   }
 }
 

--- a/app/workers/Reaper.scala
+++ b/app/workers/Reaper.scala
@@ -7,7 +7,7 @@ package workers
 import java.util.Date
 
 import akka.actor.{Actor, Props}
-
+import play.api._
 import models.{Collection, Cull, HubUtils, Item, Topic}
 import services.Emailer
 
@@ -21,7 +21,7 @@ class ReaperWorker extends Actor {
   def receive = {
     case c: Cull => Reaper.cull(c)
     case (oid: String, policy: String) => Reaper.expungeItem(oid, policy)
-    case _ => println("Unknown message")
+    case _ => Logger.error("Unhandled Case in ReaperWorker#receive")
   }
 }
 
@@ -44,7 +44,7 @@ object Reaper {
   def allow(item: Item, policy: String): Boolean = {
     policy match {
       case "soft" => itemQuiet(item) && topicsQuiet(item)
-      case _ => println("Unknown policy"); false
+      case _ => Logger.error("Unknown policy"); false
     }
   }
 

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -6,21 +6,10 @@
 
   <conversionRule conversionWord="coloredLevel" converterClass="play.api.Logger$ColoredLevel" />
 
-  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-     <file>${application.home}/logs/application.log</file>
-     <encoder>
-       <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
-     </encoder>
-  </appender>
-
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%coloredLevel %logger{100} - %message%n%xException{10}</pattern>
     </encoder>
-  </appender>
-
-  <appender name="ASYNCFILE" class="ch.qos.logback.classic.AsyncAppender">
-    <appender-ref ref="FILE" />
   </appender>
 
   <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
@@ -42,7 +31,6 @@
   <logger name="play.api.libs.concurrent.ActorSystemProvider" level="OFF" />
 
   <root level="WARN">
-    <appender-ref ref="ASYNCFILE" />
     <appender-ref ref="ASYNCSTDOUT" />
   </root>
 


### PR DESCRIPTION
Removes file based log and just uses stdout which is appropriate for
our use on Heroku, local dev and in CI.

Closes #222

Also makes the switch from println to Loggers.

All code that was actively bring println’ed has a level of Info or
Higher (i.e. Info, Warn, Error as seemed appropriate).

Commented out println statements were changed to Logger.debug with the
comments removed so they’ll show up if you change your log level
without having to uncomment/recomment a bunch of code.

A nice side effect of this work is that it should allow our external
log drains to be more useful.