### PR TITLE
Remove Scoap3 specific code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-SCOAP3 TopicHub
+TopicHub
 =================================
+This web application allows users to discover, subscribe to, and obtain automatic delivery of
+aggregations of article content repositories.
 
-This is a web application to allow users to discover, subscribe to,
-and obtain automatic delivery of, aggregations of article content from the SCOAP3 repository.
-
-[![Build Status](https://travis-ci.org/MITLibraries/scoap3hub.svg?branch=master)](https://travis-ci.org/MITLibraries/scoap3hub) [![Coverage Status](https://coveralls.io/repos/MITLibraries/scoap3hub/badge.svg?branch=master)](https://coveralls.io/r/MITLibraries/scoap3hub?branch=master)
+[![Build Status](https://travis-ci.org/MITLibraries/topichub.svg?branch=master)](https://travis-ci.org/MITLibraries/topichub) [![Coverage Status](https://coveralls.io/repos/MITLibraries/topichub/badge.svg?branch=master)](https://coveralls.io/r/MITLibraries/topichub?branch=master)
 
 Authentication
 =====
@@ -18,3 +17,22 @@ OAuth provider will be required. `AUTH_CALLBACK_URL` should be whatever domain y
 running this app on plus `/_oauth-callback`. You will need to configure that on your
 OAuth provider site as well. For development `http://localhost:9000/_oauth-callback`
 (or similar) should also be set with the provider.
+
+**A full list of settings and some examples can been seen in app/conf/authentication.conf.**
+
+Authorization
+=====
+Explicit roles `sysadmin` and `analyst` can manually be assigned in the `hub_user` table. All other
+roles are implicit so don't need to be defined.
+
+Branding
+=====
+Three Environment Variables control the branding experience.
+1. `SITE_NAME`: controls the overall branded sitename and defaults to "TopicHub"
+2. `SITE_DESCRIPTION`: allows for a description of the site to be configured for the home page.
+Html is allowed.
+3. `SITE_BASE_URL`: This is used in generated emails to provide links back to the site.
+Use the protocol and FQDN for your site. Defaults to "http://example.com" so if you get emails
+with that in them you'll want to check this value.
+
+**Developers should access those values using the HubUtils wrapper methods for consistency.**

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -297,7 +297,8 @@ object Application extends Controller with Security {
       Harvest.findById(hid).map( harvest => {
         if (harvest.publisher.get.userId == identity.id) {
           harvester ! (oid, coll, harvest, force)
-          Ok(views.html.harvest.index("pulled: " + oid))
+          Redirect(routes.Application.index).flashing(
+            "success" -> s"pulled: ${oid}")
         } else {
           Unauthorized(views.html.static.trouble("You are not authorized"))
         }
@@ -926,7 +927,7 @@ object Application extends Controller with Security {
         val subscriber = Subscriber.findById(value).get
         subscriber.linkUser(identity.id)
         val adminEmails = subscriber.adminList.map {user => user.email}.mkString(",")
-        val subject = "SCOAP3Hub Request to Join Subscriber"
+        val subject = s"${HubUtils.siteName} Request to Join Subscriber"
         val msg = views.txt.email.subscriber_join_request(subscriber, identity).body
         Emailer.subscriberEmails(adminEmails, subject, msg)
         Ok(views.html.subscriber.request())
@@ -941,7 +942,7 @@ object Application extends Controller with Security {
 
   def subscriberResolveUser(id: Int, userid: Int, res: String) = isAuthenticated { identity => implicit request =>
     val sub = Subscriber.findById(id).get
-    val subject = s"SCOAP3Hub Request to Join Subscriber ${res}"
+    val subject = s"${HubUtils.siteName} Request to Join Subscriber ${res}"
     val user = User.findById(userid).get
     val msg = views.txt.email.subscriber_resolve(sub, res).body
 

--- a/app/models/HubUtils.scala
+++ b/app/models/HubUtils.scala
@@ -80,4 +80,21 @@ object HubUtils {
     val uncovered = allItems - covered
     List(("Covered", covered), ("Uncovered", uncovered))
   }
+
+  def siteName = {
+    current.configuration.getString("brand.name").getOrElse("TopicHub")
+  }
+
+  def replyEmail = {
+    current.configuration.getString("brand.reply_email").getOrElse("noreply@example.com")
+  }
+
+  def baseUrl = {
+    current.configuration.getString("brand.site_url").getOrElse("http://example.com")
+  }
+
+  def siteDescription = {
+    current.configuration.getString("brand.site_description").getOrElse(
+      "Add a description in conf/brand.conf or by setting the SITE_DESCRIPTION Environement Variable")
+  }
 }

--- a/app/services/email.scala
+++ b/app/services/email.scala
@@ -9,6 +9,7 @@ import java.net.URLEncoder._
 import play.api._
 import play.api.libs.ws._
 import play.api.Play.current
+import models.HubUtils
 
 /** Service for email delivery
   * TODO: refactor for real plug-in modularity, this contains
@@ -29,20 +30,25 @@ trait EmailService {
   val adminEmail = Play.configuration.getString("hub.admin.email").get
 
   def notify(to: String, subject: String, msg: String) {
-    val props = Map("to" -> munge(to), "from" -> "noreply@scoap3hub.org",
-                    "subject" -> subject, "text" -> msg)
+    val props = Map("to" -> munge(to),
+                    "from" -> HubUtils.replyEmail,
+                    "subject" -> subject,
+                    "text" -> msg)
     send(props)
   }
 
   def feedback(from: String, msg: String, reply: Boolean) = {
-    val props = Map("to" -> munge(adminEmail), "from" -> from,
-                    "subject" -> "SCOAP3Hub Feedback", "text" -> msg)
+    val props = Map("to" -> munge(adminEmail),
+                    "from" -> from,
+                    "subject" -> s"${HubUtils.siteName} Feedback",
+                    "text" -> msg)
     send(if (reply) props + ("h:Reply-To" -> from) else props)
   }
 
   def subscriberEmails(to: String, subject: String, msg: String) = {
-    val props = Map("to" -> munge(to), "from" -> "noreply@scoap3hub.org",
-                    "sender" -> "noreply@scoap3hub.org",
+    val props = Map("to" -> munge(to),
+                    "from" -> HubUtils.replyEmail,
+                    "sender" -> HubUtils.replyEmail,
                     "subject" -> subject,
                     "text" -> msg)
     send(props)

--- a/app/views/collection/index.scala.html
+++ b/app/views/collection/index.scala.html
@@ -18,8 +18,8 @@
       </div>
       <div class="col-md-8">
         <div class="jumbotron">
-          <h2>Collections in SCOAP<sup>3</sup></h2>
-          <p>SCOAP content is organized by the journal in which each article appears. Browse the journal collections at left.</p>
+          <h2>Collections in @HubUtils.siteName</h2>
+          <p>Content is organized by the collection in which each item appears. Browse the collections at left.</p>
         </div>
       </div>
     </div>

--- a/app/views/cull/create.scala.html
+++ b/app/views/cull/create.scala.html
@@ -24,7 +24,7 @@
     @inputText(cullForm("notify_url"),
               'class -> "form-control",
               '_label -> "Notify URL",
-              '_help -> "ex. mailto:admin@repo.scoap3.org")
+              '_help -> "ex. mailto:admin@repo.example.org")
 
     @inputDate(cullForm("start"),
               'class -> "form-control",

--- a/app/views/email/abort_harvest.scala.txt
+++ b/app/views/email/abort_harvest.scala.txt
@@ -7,7 +7,7 @@ An error occurred starting the following harvest:
 
 Harvest: @harvest.name
 Publisher: @harvest.publisher.get.name
-Link to Harvest: http://scoap3.topichub.org/harvest/@harvest.id
+Link to Harvest: @HubUtils.baseUrl/harvest/@harvest.id
 
 Exception text:
 @exception

--- a/app/views/email/item_notify.scala.txt
+++ b/app/views/email/item_notify.scala.txt
@@ -4,7 +4,7 @@
  *****************************************************************************@
 @(item: Item)
 
-Now available on Scoap3Hub:
+Now available on @HubUtils.siteName:
 
 Title: @item.metadataValue("title")
 Authors: @item.metadataValues("author").mkString(";")

--- a/app/views/email/item_removed.scala.txt
+++ b/app/views/email/item_removed.scala.txt
@@ -4,7 +4,7 @@
  *****************************************************************************@
 @(item: Item)
 
-The following item is no longer available from Scoap3Hub:
+The following item is no longer available from @HubUtils.siteName:
 
 Title: @item.metadataValue("title")
 Authors: @item.metadataValues("author").mkString(";")

--- a/app/views/email/subscriber_resolve.scala.txt
+++ b/app/views/email/subscriber_resolve.scala.txt
@@ -6,5 +6,5 @@
 
 Your request to join Subscriber Group: @subscriber.name has been @resolution.
 
-You may visit SCOAP3Hub at:
+You may visit @HubUtils.siteName at:
 @routes.Application.index.absoluteURL()

--- a/app/views/email/sword_transfer_failure.scala.txt
+++ b/app/views/email/sword_transfer_failure.scala.txt
@@ -12,7 +12,7 @@ Channel:
 Subscriber:
 @Subscriber.findById(trans.subscriberId).get.name
 
-Link to Item: http://scoap3.topichub.org/item/@item.id
+Link to Item: @HubUtils.baseUrl/item/@item.id
 
 Exception text:
 @error

--- a/app/views/email/unhandled_collections.scala.txt
+++ b/app/views/email/unhandled_collections.scala.txt
@@ -7,7 +7,7 @@ The following collections were not handled during a Harvest:
 
 Harvest: @harvest.name
 Publisher: @harvest.publisher.get.name
-Link to Harvest: http://scoap3.topichub.org/harvest/@harvest.id
+Link to Harvest: @HubUtils.baseUrl/harvest/@harvest.id
 
 Unhandled Collections:
 @collection.map {c =>

--- a/app/views/harvest/index.scala.html
+++ b/app/views/harvest/index.scala.html
@@ -1,7 +1,0 @@
-@(message: String)(implicit request: play.api.mvc.RequestHeader)
-@layout.main("TopicHub") {
-  <div class="jumbotron">
-    <h2>Welcome to SCOAP<sup>3</sup> TopicHub!</h2>
-    <p>Getting content for your IR has never been easier! TopicHub connects you to content providers through a suite of simple, easy-to-use tools that manage the discovery and acquisition of content for your IR. Use TopicHub to establish ongoing content acquisition feeds that are customized to your institution’s operational procedures -- anything from email notifications of newly published content to fully-automated delivery of that content directly to your IR. Ready to get started?</p>
-  </div>
-}

--- a/app/views/layout/main.scala.html
+++ b/app/views/layout/main.scala.html
@@ -1,5 +1,5 @@
 @*****************************************************************************
- * Main HTML template for SCOAP3 TopicHub pages. Included by all pages       *
+ * Main HTML template for TopicHub pages. Included by all pages              *
  * Copyright (c) 2015 MIT Libraries                                          *
  *****************************************************************************@
 @(title: String)(content: Html)(implicit request: play.api.mvc.RequestHeader)
@@ -36,7 +36,7 @@
               <span class="icon-bar"></span>
               <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand" href="@routes.Application.index">SCOAP<sup>3</sup> TopicHub</a>
+            <a class="navbar-brand" href="@routes.Application.index">@HubUtils.siteName</a>
           </div>
           <div class="navbar-collapse collapse" id="th-navbar-collapse">
             <ul class="nav navbar-nav">

--- a/app/views/login/index.scala.html
+++ b/app/views/login/index.scala.html
@@ -1,6 +1,5 @@
 @(loginText: String, externalAuthUrl: String)(implicit request: play.api.mvc.RequestHeader)
-
-@layout.main("Login to SCOAP3 - TopicHub") {
+@layout.main(s"Login to ${HubUtils.siteName}") {
   <h2>Not Yet Authenticated</h2>
   <a id="openid" class="btn btn-primary" href="/_external-oauth?requestUri=@helper.urlEncode(externalAuthUrl)">
     @loginText

--- a/app/views/static/about.scala.html
+++ b/app/views/static/about.scala.html
@@ -14,5 +14,5 @@
     <li>In application web pages, metadata is expressed using the <a href="http://schema.org">Schema.org</a> vocabulary.</li>
     <li>Topics identified by the hub are syndicated as <a href="http://www.atomenabled.org">Atom</a> feeds containing items.</li>
   </ul>
-  <p>TopicHub is built upon an open-source, Apache 2 licensed platform available on <a href="https://github.com/MITLibraries/scoap3hub">GitHub</a>.</p>
+  <p>TopicHub is built upon an open-source, Apache 2 licensed platform available on <a href="https://github.com/MITLibraries/topichub">GitHub</a>.</p>
 }

--- a/app/views/static/feedback.scala.html
+++ b/app/views/static/feedback.scala.html
@@ -10,7 +10,7 @@
 
   <h2>We'd love to hear from you!</h2>
 
-  <p>Thanks for helping make SCOAP3 TopicHub a more valuable service!</p>
+  <p>Thanks for helping make @HubUtils.siteName a more valuable service!</p>
 
   @form(routes.Application.takeFeedback, 'class -> "form-horizontal") {
     <span id="helpBlock" class="help-block">* Denotes Required Element</span>

--- a/app/views/static/home.scala.html
+++ b/app/views/static/home.scala.html
@@ -1,10 +1,9 @@
 @*****************************************************************************
-* Front page for SCOAP3-bound topichub, also providing entry point for       *
-* topic browsing                                                             *
+* Front page for topichub, also providing entry point for topic browsing     *
 * Copyright (c) 2015 MIT Libraries                                           *
 *****************************************************************************@
 @(schemes: List[Scheme])(implicit request: play.api.mvc.RequestHeader)
-@layout.main("SCOAP3 -  TopicHub") {
+@layout.main(s"${HubUtils.siteName}") {
   <div class="container-fluid">
     <div class="row-fluid">
       <div class="col-md-4">
@@ -25,11 +24,7 @@
       </div>
       <div class="col-md-8">
         <div class="jumbotron">
-          <h2>Welcome to SCOAP<sup>3</sup> TopicHub!</h2>
-          <p>SCOAP<sup>3</sup> (Sponsoring Consortium for Open Access Publishing in Particle Physics) is a <a href="http://cern.ch">CERN</a>-managed service to deliver High-Energy Physics articles as open access. Visit them <a href="http://repo.scoap3.org">here</a>.</p>
-          <p>The hub analyzes each article in the SCOAP<sup>3</sup> repository to extract <em>topics</em>. A topic is an identifier or term belonging to a standard vocabulary or name-space, known as its <em>scheme</em>.
-             Relative to this scheme, the topic identifies, describes, characterizes or classifies the article. Topics help organize articles into groups that are of interest to subscribers:
-             all articles in a particular journal, everything written by a certain author, etc. Find the topics (or articles) you want by <a href="@routes.Search.index">searching</a>, or explore topics within a scheme by clicking on one of the scheme browse links at the left.</p>
+          @Html(HubUtils.siteDescription)
         </div>
       </div>
     </div>

--- a/app/views/static/sandbox.scala.html
+++ b/app/views/static/sandbox.scala.html
@@ -18,7 +18,7 @@
               'class -> "form-control")
     @inputText(sbForm("resourceUrl"),
               '_label -> "* Resource URL",
-              '_help -> "ex: http://repo.scoap3.org/record/10405/export/xm?ln=en",
+              '_help -> "ex: http://repo.example.org/record/10405/export/xm?ln=en",
               'size -> 50,
               'class -> "form-control")
 

--- a/app/views/static/workbench.scala.html
+++ b/app/views/static/workbench.scala.html
@@ -25,12 +25,8 @@
           <a id="sidenav_cformats" href="@routes.Application.contentFormats" class="list-group-item">Content Formats</a>
           <a id="sidenav_cprofiles" href="@routes.Application.contentProfiles" class="list-group-item">Content Profiles</a>
           <a id="sidenav_rmaps" href="@routes.Application.resourceMaps" class="list-group-item">Resource Maps</a>
-            @* next choice specific to a UI bound, like SCOAP3, to a single publisher: need a place to set it up *@
-            @* In the multi-publisher case, this link is at the top level *@
           <a id="sidenav_publishers" href="@routes.Application.publishers" class="list-group-item">Publishers</a>
-          @* likewise, next choice would top-level if open to all subscribers *@
           <a id="sidenav_subscribers" href="@routes.Application.subscribers" class="list-group-item">Subscribers</a>
-          @* this will be moved to subscriber-based links when multiple subscribers allowed *@
           <a id="sidenav_plans" href="@routes.Application.newPlan(1)" class="list-group-item">Plans</a>
           @*<a href="@routes.Application.pkgmaps" class="list-group-item">Packages</a>*@
           <a id="sidenav_sandbox" href="@routes.Application.sandbox" class="list-group-item">Sandbox</a>

--- a/app/workers/Conveyor.scala
+++ b/app/workers/Conveyor.scala
@@ -15,7 +15,7 @@ import play.api.libs.ws._
 import play.api.mvc._
 import play.api.http.HeaderNames._
 
-import models.{Agent, Channel, Hold, Interest, Item, Plan, Scheme, Subscriber,
+import models.{Agent, Channel, Hold, HubUtils, Interest, Item, Plan, Scheme, Subscriber,
                Subscription, Topic, TopicPick, Transfer, User}
 import services.Emailer
 
@@ -34,7 +34,7 @@ class ConveyorWorker extends Actor {
     case (item: Item, subscr: Subscriber) => Conveyor.transferItem(item, subscr)
     case (hold: Hold, accept: Boolean) => Conveyor.resolveHold(hold, accept)
     case (pick: TopicPick, accept: Boolean) => Conveyor.resolvePick(pick, accept)
-    case _ => Logger.error("Unhandle Case in ConveryWorker#receive")
+    case _ => Logger.error("Unhandled Case in ConveryWorker#receive")
   }
 }
 
@@ -257,7 +257,7 @@ object Conveyor {
 
     def sendSwordFailureEmail(addresses: String, msg: String) = {
       Logger.info(msg)
-      Emailer.notify(addresses, "SCOAP3Hub: failure of sword delivery detected", msg)
+      Emailer.notify(addresses, s"${HubUtils.siteName}: failure of sword delivery detected", msg)
       Transfer.delete(trans.id)
     }
 
@@ -279,6 +279,6 @@ object Conveyor {
     val text = views.txt.email.item_notify(item)
     val topic = sub.topic
     Emailer.notify(sub.subscriber.contact,
-        "Scoap3Hub Alert - new in " + topic.tag + ":" + topic.name, text.body)
+        s"${HubUtils.siteName} Alert - new in ${topic.tag}: ${topic.name}", text.body)
   }
 }

--- a/app/workers/Harvester.scala
+++ b/app/workers/Harvester.scala
@@ -90,7 +90,7 @@ class Harvester {
       val sysadminEmails = User.allByRole("sysadmin").map(x => x.email).mkString(",")
       val msg = views.txt.email.unhandled_collections(harvest, collections).body
       Logger.warn(msg)
-      Emailer.notify(sysadminEmails, "SCOAP3Hub: An unhandled collection was detected", msg)
+      Emailer.notify(sysadminEmails, s"${HubUtils.siteName}: An unhandled collection was detected", msg)
     }
 
     def handleOaiError(errorText: String, errorCode: String) = {
@@ -131,7 +131,7 @@ class Harvester {
       val sysadminEmails = User.allByRole("sysadmin").map(x => x.email).mkString(",")
       val msg = views.txt.email.abort_harvest(harvest, exception).body
       Logger.error(msg)
-      Emailer.notify(sysadminEmails, "SCOAP3Hub: An error occurred starting a Harvest", msg)
+      Emailer.notify(sysadminEmails, s"${HubUtils.siteName} An error occurred starting a Harvest", msg)
     }
 
     // OAI-PMH date filters are inclusive on both ends (from and until),

--- a/app/workers/Reaper.scala
+++ b/app/workers/Reaper.scala
@@ -72,7 +72,7 @@ object Reaper {
     if (notifyUrl.isDefined && notifyUrl.get.startsWith("mailto:")) {
       val recip = notifyUrl.get.substring(7)
       val msg = views.txt.email.item_removed(item)
-      Emailer.notify(recip, "Item Removed from SCOAP3Hub", msg.body)
+      Emailer.notify(recip, s"Item Removed from ${HubUtils.siteName}", msg.body)
     }
     // Finally delete item itself
     Item.delete(item.id)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -69,3 +69,9 @@ include "authentication"
 # keys allowed to start non-authenticated harvests
 auth.harvest.key = ""
 auth.harvest.key = ${?HARVEST_KEY}
+
+# Branding changes should be made using Environment Variables
+# Developers should access values via the HubUtils model rather than directly.
+brand.name=${?SITE_NAME}
+brand.site_description=${?SITE_DESCRIPTION}
+brand.base_url=${?SITE_BASE_URL}

--- a/test/ApplicationSpec.scala
+++ b/test/ApplicationSpec.scala
@@ -29,7 +29,7 @@ class ApplicationSpec extends Specification {
 
       status(home) must equalTo(OK)
       contentType(home) must beSome.which(_ == "text/html")
-      contentAsString(home) must contain ("Welcome to SCOAP")
+      contentAsString(home) must contain ("Add a description in conf/brand.conf")
     }
 
     "display a login screen" in new WithApplication(FakeApplication(additionalConfiguration = inMemoryDatabase())) {

--- a/test/integration/AuthenticationPagesSpec.scala
+++ b/test/integration/AuthenticationPagesSpec.scala
@@ -24,14 +24,14 @@ class AuthenticationPageSpec extends Specification with Mockito {
     "display a login screen" in new WithBrowser(app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
       browser.goTo("http://localhost:" + port + "/login")
       browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
-      assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+      assertThat(browser.title()).isEqualTo("Login to TopicHub")
     }
 
     "Analyst protected pages" should {
       "prompt for login when not signed in" in new WithBrowser(app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         browser.goTo("http://localhost:" + port + "/workbench")
         browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       "deny access when signed in without analyst role" in new WithBrowser(app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
@@ -66,7 +66,7 @@ class AuthenticationPageSpec extends Specification with Mockito {
       "prompt for login when not signed in" in new WithBrowser(app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         browser.goTo("http://localhost:" + port + "/dashboard")
         browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       "create user if authentication passes and no local user exists" in new WithBrowser(

--- a/test/integration/ChannelPagesSpec.scala
+++ b/test/integration/ChannelPagesSpec.scala
@@ -26,7 +26,7 @@ class ChannelPagesSpec extends Specification {
         val ch = Channel.make(sub.id, "protocol", "mode", "description", "userid",
                               "password", "http://example.com")
         browser.goTo("http://localhost:" + port + "/channel/" + ch.id)
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // GET /channels/:sid/create
@@ -36,7 +36,7 @@ class ChannelPagesSpec extends Specification {
         val sub = Subscriber.make(sub_user.id, "Sub Name", "cat", "contact",
                                   Some("link"), Some("logo"))
         browser.goTo("http://localhost:" + port + "/channels/" + sub.id + "/create")
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // POST /subscriber/:sid/channels

--- a/test/integration/CollectionPagesSpec.scala
+++ b/test/integration/CollectionPagesSpec.scala
@@ -54,7 +54,7 @@ class CollectionPagesSpec extends Specification {
         val pub = Publisher.make(pub_user.id, "pubtag", "pubname", "pubdesc", "pubcat",
                                  "pubstatus", Some("http://www.example.com"), Some(""))
         browser.goTo("http://localhost:" + port + "/publisher/" + pub.id + "/create")
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
     }
 

--- a/test/integration/ContentFormatPagesSpec.scala
+++ b/test/integration/ContentFormatPagesSpec.scala
@@ -24,7 +24,7 @@ class ContentFormatPagesSpec extends Specification {
       "accessing index redirects to login" in new WithBrowser(
         app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         browser.goTo("http://localhost:" + port + "/cformats")
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // GET /cformat/:id
@@ -33,14 +33,14 @@ class ContentFormatPagesSpec extends Specification {
         val cf = ContentFormat.make("cf_tag", "cf_label", "cf_desc", "http://www.example.com",
                                     "mimetype", Some("logo"))
         browser.goTo("http://localhost:" + port + "/cformat/" + cf.id)
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // GET /cformats/create
       "accessing content format create form redirects to login" in new WithBrowser(
         app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         browser.goTo("http://localhost:" + port + "/cformats/create")
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // POST /cformats

--- a/test/integration/ContentTypePagesSpec.scala
+++ b/test/integration/ContentTypePagesSpec.scala
@@ -24,7 +24,7 @@ class ContentTypePagesSpec extends Specification {
       "accessing index redirects to login" in new WithBrowser(
         app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         browser.goTo("http://localhost:" + port + "/ctypes")
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // GET /ctype/:id
@@ -32,14 +32,14 @@ class ContentTypePagesSpec extends Specification {
         app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         val ct = ContentType.make("tag", "label", "desc", Some("logo"))
         browser.goTo("http://localhost:" + port + "/ctype/" + ct.id)
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // GET /ctypes/create
       "accessing content type create form redirects to login" in new WithBrowser(
         app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         browser.goTo("http://localhost:" + port + "/ctypes/create")
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // POST /ctypes
@@ -68,7 +68,7 @@ class ContentTypePagesSpec extends Specification {
         ct.schemes("relation") must haveSize(1)
         browser.goTo("http://localhost:" + port + "/ctype/" + ct.id +
                      "/scheme?relation=relation&sid=" + s.id)
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
         ct.schemes("relation") must haveSize(1)
       }
     }

--- a/test/integration/CullPagesSpec.scala
+++ b/test/integration/CullPagesSpec.scala
@@ -28,7 +28,7 @@ class CullPagesSpec extends Specification {
                                  "pubstatus", Some("http://www.example.com"), Some(""))
         browser.goTo("http://localhost:" + port + "/publisher/" + pub.id + "/createC")
         browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // POST /cull/:id (publisher ID)
@@ -51,7 +51,7 @@ class CullPagesSpec extends Specification {
         val cull = Cull.make(pub.id, "name", "soft", None, 1, new Date)
         browser.goTo("http://localhost:" + port + "/cull/" + cull.id)
         browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // GET /cull/:id/start
@@ -64,7 +64,7 @@ class CullPagesSpec extends Specification {
         browser.goTo("http://localhost:" + port + "/cull/" + cull.id + "/start?span=1")
         Cull.findById(cull.id).get.updated must equalTo(cull.updated)
         browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       //GET /cull/:id/delete
@@ -77,7 +77,7 @@ class CullPagesSpec extends Specification {
         browser.goTo("http://localhost:" + port + "/cull/" + cull.id + "/delete")
         Cull.findById(cull.id).get must equalTo(cull)
         browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // GET /knix/:cid/:oid
@@ -93,7 +93,7 @@ class CullPagesSpec extends Specification {
         browser.goTo("http://localhost:" + port + "/knix/" + collection.id +
                      "/scoap:asdf:fdsa")
         browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
     }
 

--- a/test/integration/DashboardPagesSpec.scala
+++ b/test/integration/DashboardPagesSpec.scala
@@ -22,7 +22,7 @@ class DashboardPagesSpec extends Specification {
     "prompts for login when not signed in" in new WithBrowser(app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
       browser.goTo("http://localhost:" + port + "/dashboard")
       browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
-      assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+      assertThat(browser.title()).isEqualTo("Login to TopicHub")
     }
 
     "allows access when signed in if a Subscriber is associated with the User" in new WithBrowser(app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {

--- a/test/integration/FinderPagesSpec.scala
+++ b/test/integration/FinderPagesSpec.scala
@@ -25,7 +25,7 @@ class FinderPagesSpec extends Specification {
         app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         val s = Scheme.make("tag", "gentype", "cat", "desc", Some("link"), Some("logo"))
         browser.goTo("http://localhost:" + port + "/scheme/" + s.tag + "/finders")
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // GET /scheme/:tag/create
@@ -33,7 +33,7 @@ class FinderPagesSpec extends Specification {
         app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         val s = Scheme.make("tag", "gentype", "cat", "desc", Some("link"), Some("logo"))
         browser.goTo("http://localhost:" + port + "/scheme/" + s.tag + "/create")
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // POST /scheme/:tag
@@ -53,7 +53,7 @@ class FinderPagesSpec extends Specification {
         val f = Finder.make(s.id, cf.id, "description", "card", "idkey", "idlabel", "author")
         Finder.findByScheme(s.id).size must equalTo(1)
         browser.goTo("http://localhost:" + port + "/scheme/" + s.tag + "/finder/" + f.id + "/delete")
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
         Finder.findByScheme(s.id).size must equalTo(1)
       }
     }

--- a/test/integration/HarvestPagesSpec.scala
+++ b/test/integration/HarvestPagesSpec.scala
@@ -28,7 +28,7 @@ class HarvestPagesSpec extends Specification {
                                  "pubstatus", Some("http://www.example.com"), Some(""))
         browser.goTo("http://localhost:" + port + "/publisher/" + pub.id + "/createH")
         browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // POST /harvest/:id (publisher ID)
@@ -52,7 +52,7 @@ class HarvestPagesSpec extends Specification {
                                    "http://example.org", 1, new Date)
         browser.goTo("http://localhost:" + port + "/harvest/" + harvest.id)
         browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // GET /harvest/:id/start
@@ -66,7 +66,7 @@ class HarvestPagesSpec extends Specification {
         browser.goTo("http://localhost:" + port + "/harvest/" + harvest.id + "/start?span=1")
         Harvest.findById(harvest.id).get.updated must equalTo(harvest.updated)
         browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       //GET /harvest/:id/delete
@@ -80,7 +80,7 @@ class HarvestPagesSpec extends Specification {
         browser.goTo("http://localhost:" + port + "/harvest/" + harvest.id + "/delete")
         Harvest.findById(harvest.id).get must equalTo(harvest)
         browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // GET /knip/:cid/:hid/:oid
@@ -97,7 +97,7 @@ class HarvestPagesSpec extends Specification {
         browser.goTo("http://localhost:" + port + "/knip/" + collection.id + "/" + harvest.id +
                      "/scoap:asdf:fdsa")
         browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
     }
 

--- a/test/integration/HoldPagesSpec.scala
+++ b/test/integration/HoldPagesSpec.scala
@@ -34,7 +34,7 @@ class HoldPagesSpec extends Specification {
         val item = Item.make(col.id, ct.id, "location", "scoap:abc:123")
         Hold.create(sub.id, subscr.id, item.id)
         browser.goTo("http://localhost:" + port + "/holds/browse?id=" + sub.id)
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // GET /hold/:id/resolve?accept=Boolean
@@ -54,7 +54,7 @@ class HoldPagesSpec extends Specification {
         var h = Hold.make(sub.id, subscr.id, item.id)
         Hold.held(item.id, sub.id) must equalTo(true)
         browser.goTo("http://localhost:" + port + "/hold/" + h.id + "/resolve?accept=false")
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
         Hold.held(item.id, sub.id) must equalTo(true)
         pending("see https://github.com/MITLibraries/scoap3hub/issues/170")
       }

--- a/test/integration/PlanPagesSpec.scala
+++ b/test/integration/PlanPagesSpec.scala
@@ -29,7 +29,7 @@ class PlanPagesSpec extends Specification {
                           "review", "subscribe", "review")
 
         browser.goTo("http://localhost:" + port + "/plan/" + p.id)
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // GET /plans/:sid/create
@@ -39,7 +39,7 @@ class PlanPagesSpec extends Specification {
         val sub = Subscriber.make(sub_user.id, "Sub Name", "cat", "contact",
                                   Some("link"), Some("logo"))
         browser.goTo("http://localhost:" + port + "/plans/" + sub.id + "/create")
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // POST /plans/:sid
@@ -96,7 +96,7 @@ class PlanPagesSpec extends Specification {
         p.addScheme(scheme)
         p.schemes.size must equalTo(1)
         browser.goTo("http://localhost:" + port + "/plan/" + p.id + "/remove/" + scheme.id)
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
         p.schemes.size must equalTo(1)
       }
     }

--- a/test/integration/PublisherPagesSpec.scala
+++ b/test/integration/PublisherPagesSpec.scala
@@ -113,7 +113,7 @@ class PublisherPagesSpec extends Specification {
         browser.goTo("http://localhost:" + port + "/publishers")
         browser.$("a[href*='/publishers/create']").click()
         browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       "display create publisher form if signed in" in new WithBrowser(app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
@@ -144,7 +144,7 @@ class PublisherPagesSpec extends Specification {
         val pub = Publisher.make(pub_user.id, "pubtag", "pubname", "pubdesc", "pubcat", "pubstatus", Some("http://www.example.com"), Some(""))
         browser.goTo("http://localhost:" + port + "/publisher/1/edit")
         browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       "redirects to trouble if user does not own publisher" in new WithBrowser(app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {

--- a/test/integration/ResourceMapPagesSpec.scala
+++ b/test/integration/ResourceMapPagesSpec.scala
@@ -24,7 +24,7 @@ class ResourceMapPagesSpec extends Specification {
       "accessing index page redirects to login" in new WithBrowser(
         app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         browser.goTo("http://localhost:" + port + "/resmaps")
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // GET /resmap/:id
@@ -32,14 +32,14 @@ class ResourceMapPagesSpec extends Specification {
         app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         val rm = ResourceMap.make("rm_tag", "rm_desc", Some("http://www.example.com"))
         browser.goTo("http://localhost:" + port + "/resmap/" + rm.id)
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // GET /resmaps/create
       "accessing new form page redirects to login" in new WithBrowser(
         app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         browser.goTo("http://localhost:" + port + "/resmaps/create")
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // POST /resmaps
@@ -73,7 +73,7 @@ class ResourceMapPagesSpec extends Specification {
         rm.mappingsForScheme(s).size must equalTo(1)
         browser.goTo("http://localhost:" + port + "/resmap/" + rm.id + "/scheme?sid=" +
                      s.id +"&source=source")
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
         rm.mappingsForScheme(s).size must equalTo(1)
       }
     }

--- a/test/integration/SchemePagesSpec.scala
+++ b/test/integration/SchemePagesSpec.scala
@@ -50,14 +50,14 @@ class SchemePagesSpec extends Specification {
         app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         val s1 = Scheme.make("s1_tag", "gentype", "cat", "s1_desc", Some("link"), Some("logo"))
         browser.goTo("http://localhost:" + port + "/scheme/" + s1.id + "/edit")
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // GET /schemes/create
       "accessing new scheme create form redirects to login" in new WithBrowser(
         app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         browser.goTo("http://localhost:" + port + "/schemes/create")
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // POST /schemes

--- a/test/integration/StaticPagesSpec.scala
+++ b/test/integration/StaticPagesSpec.scala
@@ -16,8 +16,8 @@ class StaticPagesSpec extends Specification {
   "home" should {
     "displays welcome message" in new WithBrowser(app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
       browser.goTo("http://localhost:" + port)
-      browser.pageSource must contain("Welcome to SCOAP")
-      assertThat(browser.title()).isEqualTo("SCOAP3 - TopicHub")
+      browser.pageSource must contain("Add a description in conf/brand.conf")
+      assertThat(browser.title()).isEqualTo("TopicHub")
     }
 
     "displays Schemes with counts" in new WithBrowser(app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
@@ -37,7 +37,7 @@ class StaticPagesSpec extends Specification {
 
     "link to github" in new WithBrowser(app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
       browser.goTo("http://localhost:" + port + "/about")
-      browser.pageSource must contain("https://github.com/MITLibraries/scoap3hub")
+      browser.pageSource must contain("https://github.com/MITLibraries/topichub")
     }
   }
 

--- a/test/integration/SubscriberInterestPagesSpec.scala
+++ b/test/integration/SubscriberInterestPagesSpec.scala
@@ -23,7 +23,7 @@ class SubscriberInterestPagesSpec extends Specification {
       "browse redirects to login" in new WithBrowser(
         app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         browser.goTo("http://localhost:" + port + "/interests/browse?filter=scheme&value=Institution")
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // POST /interests
@@ -42,7 +42,7 @@ class SubscriberInterestPagesSpec extends Specification {
         val i = Interest.make(sub.id, scheme.tag, "MIT", false)
         i must equalTo(Interest.findById(1).get)
         browser.goTo("http://localhost:" + port + "/interests/remove/" + i.id)
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
         i must equalTo(Interest.findById(1).get)
       }
     }

--- a/test/integration/SubscriberPageSpec.scala
+++ b/test/integration/SubscriberPageSpec.scala
@@ -46,7 +46,7 @@ class SubscriberPagesSpec extends Specification {
       "accessing new form redirects to login" in new WithBrowser(
         app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         browser.goTo("http://localhost:" + port + "/subscribers/create")
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // POST /subscribers
@@ -63,7 +63,7 @@ class SubscriberPagesSpec extends Specification {
         val sub = Subscriber.make(sub_user.id, "Sub Name", "cat", "contact",
                                   Some("link"), Some("logo"))
         browser.goTo("http://localhost:" + port + "/subscriber/" + sub.id + "/edit")
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // GET /subscriber/:id

--- a/test/integration/SubscriberUserPagesSpec.scala
+++ b/test/integration/SubscriberUserPagesSpec.scala
@@ -24,7 +24,7 @@ class SubscriberUserPagesSpec extends Specification {
     "prompt for login when not signed in" in new WithBrowser(
         app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
       browser.goTo("http://localhost:" + port + "/subscribers/create")
-      assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+      assertThat(browser.title()).isEqualTo("Login to TopicHub")
       browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
     }
 
@@ -53,7 +53,7 @@ class SubscriberUserPagesSpec extends Specification {
     "prompt for login when not signed in" in new WithBrowser(
         app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
       browser.goTo("http://localhost:" + port + "/subscribers/join")
-      assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+      assertThat(browser.title()).isEqualTo("Login to TopicHub")
       browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
     }
 
@@ -103,7 +103,7 @@ class SubscriberUserPagesSpec extends Specification {
       val sub = make_subscriber(sub_user.id)
 
       browser.goTo("http://localhost:" + port + "/subscriber/1/users")
-      assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+      assertThat(browser.title()).isEqualTo("Login to TopicHub")
       browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
     }
 

--- a/test/integration/SubscriptionPagesSpec.scala
+++ b/test/integration/SubscriptionPagesSpec.scala
@@ -27,7 +27,7 @@ class SubscriptionPagesSpec extends Specification {
         val t = Topic.make(scheme.id, "tag0", "name0")
         Subscription.create(sub.id, t.id, "deliver", sub.created, sub.created)
         browser.goTo("http://localhost:" + port + "/subscriptions/browse?filter=scheme&value=" + scheme.id)
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
     }
 

--- a/test/integration/SysAdminPagesSpec.scala
+++ b/test/integration/SysAdminPagesSpec.scala
@@ -24,7 +24,7 @@ class SysAdminPagesSpec extends Specification {
       "as an unauthenticated User redirects to login" in new WithBrowser(
         app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         browser.goTo("http://localhost:" + port + "/reindex/topic")
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       "as an analyst redirects to Error" in new WithBrowser(
@@ -52,7 +52,7 @@ class SysAdminPagesSpec extends Specification {
       "as an unauthenticated User redirects to login" in new WithBrowser(
         app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         browser.goTo("http://localhost:" + port + "/workbench")
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       "as an analyst displays workbench" in new WithBrowser(
@@ -80,7 +80,7 @@ class SysAdminPagesSpec extends Specification {
       "as an unauthenticated User redirects to login" in new WithBrowser(
         app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         browser.goTo("http://localhost:" + port + "/purge")
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       "as an analyst redirects to Error" in new WithBrowser(
@@ -108,7 +108,7 @@ class SysAdminPagesSpec extends Specification {
       "as an unauthenticated User redirects to login" in new WithBrowser(
         app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         browser.goTo("http://localhost:" + port + "/sandbox")
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       "as an analyst displays form" in new WithBrowser(
@@ -164,7 +164,7 @@ class SysAdminPagesSpec extends Specification {
       "as an unauthenticated User redirects to login" in new WithBrowser(
         app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         browser.goTo("http://localhost:" + port + "/model/create")
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       "as an analyst redirects to error" in new WithBrowser(

--- a/test/integration/TopicPagesSpec.scala
+++ b/test/integration/TopicPagesSpec.scala
@@ -56,7 +56,7 @@ class TopicPagesSpec extends Specification {
         app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         topic_factory(1)
         browser.goTo("http://localhost:" + port + "/topic/1/subscribe")
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // GET /topics/browse

--- a/test/integration/TopicPickPagesSpec.scala
+++ b/test/integration/TopicPickPagesSpec.scala
@@ -29,7 +29,7 @@ class TopicPickPagesSpec extends Specification {
         val a = Agent.make("tag", "label", "description", "code", "params", Some("icon"))
         TopicPick.create(sub.id, t.id, a.id)
         browser.goTo("http://localhost:" + port + "/picks/browse?id=" + sub.id)
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // GET /pick/:id/resolve?accept=Boolean
@@ -44,7 +44,7 @@ class TopicPickPagesSpec extends Specification {
         val tp = TopicPick.make(sub.id, t.id, a.id)
         sub.pickCount must equalTo(1)
         browser.goTo("http://localhost:" + port + "/pick/" + tp.id + "/resolve?accept=true")
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
         sub.pickCount must equalTo(1)
       }
     }

--- a/test/integration/UserDashboardPagesSpec.scala
+++ b/test/integration/UserDashboardPagesSpec.scala
@@ -21,7 +21,7 @@ class UserDashboardPagesSpec extends Specification {
         app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
       browser.goTo("http://localhost:" + port + "/myaccount")
       browser.pageSource must contain(Play.configuration.getString("auth.login_text").get)
-      assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+      assertThat(browser.title()).isEqualTo("Login to TopicHub")
     }
 
     "Displays the current user's data when signed in" in new WithBrowser(

--- a/test/integration/ValidatorPagesSpec.scala
+++ b/test/integration/ValidatorPagesSpec.scala
@@ -25,7 +25,7 @@ class ValidatorPagesSpec extends Specification {
         app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         val s = Scheme.make("s1_tag", "gentype", "cat", "s1_desc", Some("link"), Some("logo"))
         browser.goTo("http://localhost:" + port + "/scheme/" + s.tag + "/createvalidator")
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
       }
 
       // POST /scheme/:tag/validator
@@ -46,7 +46,7 @@ class ValidatorPagesSpec extends Specification {
         Validator.findByScheme(s.id).size must equalTo(1)
         browser.goTo("http://localhost:" + port + "/scheme/" + s.tag + "/validator/" + v.id +
                      "/delete")
-        assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+        assertThat(browser.title()).isEqualTo("Login to TopicHub")
         Validator.findByScheme(s.id).size must equalTo(1)
       }
     }

--- a/test/integration/WorkbenchPagesSpec.scala
+++ b/test/integration/WorkbenchPagesSpec.scala
@@ -23,8 +23,8 @@ class WorkbenchPagesSpec extends Specification {
   "Application" should {
     "work from within a browser" in new WithBrowser(app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
       browser.goTo("http://localhost:" + port)
-      browser.pageSource must contain("Welcome to SCOAP")
-      assertThat(browser.title()).isEqualTo("SCOAP3 - TopicHub")
+      browser.pageSource must contain("Add a description in conf/brand.conf")
+      assertThat(browser.title()).isEqualTo("TopicHub")
     }
 
     "top navigation should allow Workbench access to analyst" in new WithBrowser(app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
@@ -32,7 +32,7 @@ class WorkbenchPagesSpec extends Specification {
       browser.goTo("http://localhost:" + port + "/login")
       browser.$("#openid").click
       browser.goTo("http://localhost:" + port)
-      browser.$(".navbar-header a").getTexts().get(0) must equalTo("SCOAP3 TopicHub")
+      browser.$(".navbar-header a").getTexts().get(0) must equalTo("TopicHub")
       browser.$("body > nav > div > div.navbar-header > button").click();
       browser.$("a[href*='workbench']").click();
       assertThat(browser.title()).isEqualTo("Workbench - TopicHub")
@@ -49,7 +49,7 @@ class WorkbenchPagesSpec extends Specification {
 
     "deny Workbench access to not logged in user" in new WithBrowser(app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
       browser.goTo("http://localhost:" + port + "/workbench")
-      assertThat(browser.title()).isEqualTo("Login to SCOAP3 - TopicHub")
+      assertThat(browser.title()).isEqualTo("Login to TopicHub")
     }
   }
 


### PR DESCRIPTION
closes #310

Also modifies redirect of successful knip.

The badges in the readme and link to the repo in the footer are pointing at the future repository location after rename so they'll be broken until we do that step.